### PR TITLE
legacy-support: change comment style

### DIFF
--- a/include/MacportsLegacySupport.h
+++ b/include/MacportsLegacySupport.h
@@ -20,27 +20,27 @@
 
 #include "AvailabilityMacros.h"
 
-// defines for when legacy support is required for various functions
+/* defines for when legacy support is required for various functions */
 
-// clock_gettime
+/* clock_gettime */
 #define __MP_LEGACY_SUPPORT_GETTIME__ __APPLE__ && __ENVIRONMENT_MAC_OS_X_VERSION_MIN_REQUIRED__ < 101200
 
-// strnlen
+/* strnlen */
 #define __MP_LEGACY_SUPPORT_STRNLEN__ __APPLE__ && __ENVIRONMENT_MAC_OS_X_VERSION_MIN_REQUIRED__ < 1070
 
-// strndup
+/* strndup */
 #define __MP_LEGACY_SUPPORT_STRNDUP__ __APPLE__ && __ENVIRONMENT_MAC_OS_X_VERSION_MIN_REQUIRED__ < 1070
 
-// getline
+/* getline */
 #define __MP_LEGACY_SUPPORT_GETLINE__ __APPLE__ && __ENVIRONMENT_MAC_OS_X_VERSION_MIN_REQUIRED__ < 1070
 
-// memmem
+/* memmem */
 #define __MP_LEGACY_SUPPORT_MEMMEM__  __APPLE__ && __ENVIRONMENT_MAC_OS_X_VERSION_MIN_REQUIRED__ < 1070
 
-// wcsdup
+/* wcsdup */
 #define __MP_LEGACY_SUPPORT_WCSDUP__  __APPLE__ && __ENVIRONMENT_MAC_OS_X_VERSION_MIN_REQUIRED__ < 1070
 
-// llround
+/* llround */
 #define __MP_LEGACY_SUPPORT_LLROUND__  __APPLE__ && __ENVIRONMENT_MAC_OS_X_VERSION_MIN_REQUIRED__ < 1070
 
 #endif /* _MACPORTS_LEGACYSUPPORTDEFS_H_ */

--- a/include/cmath
+++ b/include/cmath
@@ -18,18 +18,18 @@
 #ifndef _MACPORTS_CMATH_H_
 #define _MACPORTS_CMATH_H_
 
-// Include the primary system cmath
+/* Include the primary system cmath */
 #include_next <cmath>
 
-// MP support header
+/* MP support header */
 #include "MacportsLegacySupport.h"
 
-// llround
+/* llround */
 #if __MP_LEGACY_SUPPORT_LLROUND__
 #ifdef __cplusplus
 extern "C" {
 #endif
-  // Apparently present in library but header declarations are missing in 10.6
+  /* Apparently present in library but header declarations are missing in 10.6 */
   extern long long int llrint   ( double );
   extern long long int llrintf  ( float );
   extern long long int llround  ( double );
@@ -41,4 +41,4 @@ extern "C" {
 #endif
 #endif
 
-#endif // _MACPORTS_CMATH_H_
+#endif /* _MACPORTS_CMATH_H_ */

--- a/include/stdio.h
+++ b/include/stdio.h
@@ -18,15 +18,15 @@
 #ifndef _MACPORTS_STDIO_H_
 #define _MACPORTS_STDIO_H_
 
-// Include the primary system time.h
+/* Include the primary system time.h */
 #include_next <stdio.h>
 
-// MP support header
+/* MP support header */
 #include "MacportsLegacySupport.h"
 
-// getline
+/* getline */
 #if __MP_LEGACY_SUPPORT_GETLINE__
-//#include <unistd.h> /* ssize_t */
+/* #include <unistd.h> */ /* ssize_t */
 typedef long ssize_t;	
 #ifdef __cplusplus
 extern "C" {
@@ -38,4 +38,4 @@ extern "C" {
 #endif
 #endif
 
-#endif // _MACPORTS_STDIO_H_
+#endif /* _MACPORTS_STDIO_H_ */

--- a/include/string.h
+++ b/include/string.h
@@ -18,13 +18,13 @@
 #ifndef _MACPORTS_STRING_H_
 #define _MACPORTS_STRING_H_
 
-// Include the primary system string.h
+/* Include the primary system string.h */
 #include_next <string.h>
 
-// MP support header
+/* MP support header */
 #include "MacportsLegacySupport.h"
 
-// strnlen
+/* strnlen */
 #if __MP_LEGACY_SUPPORT_STRNLEN__
 #ifdef __cplusplus
 extern "C" {
@@ -35,7 +35,7 @@ extern "C" {
 #endif
 #endif
 
-// strndup
+/* strndup */
 #if __MP_LEGACY_SUPPORT_STRNDUP__
 #ifdef __cplusplus
 extern "C" {
@@ -46,7 +46,7 @@ extern "C" {
 #endif
 #endif
 
-// memmem
+/* memmem */
 #if __MP_LEGACY_SUPPORT_MEMMEM__
 #ifdef __cplusplus
 extern "C" {
@@ -58,4 +58,4 @@ extern "C" {
 #endif
 #endif
 
-#endif // _MACPORTS_STRING_H_
+#endif /* _MACPORTS_STRING_H_ */

--- a/include/sys/fcntl.h
+++ b/include/sys/fcntl.h
@@ -18,12 +18,14 @@
 #ifndef _MACPORTS_SYSFCNTL_H_
 #define _MACPORTS_SYSFCNTL_H_
 
-// Include the primary system wchar.h
+/* Include the primary system wchar.h */
 #include_next <sys/fcntl.h>
 
-// replace missing O_CLOEXIT definition with 0, which works
-// but does not replace the full function of that flag
-// this is the commonly done fix in MacPorts (see gtk3, for example)
+/* replace missing O_CLOEXEC definition with 0, which works
+ * but does not replace the full function of that flag
+ * this is the commonly done fix in MacPorts (see gtk3, for example) 
+ */
+
 #ifndef O_CLOEXEC
 #define O_CLOEXEC 0
 #endif

--- a/include/sys/mman.h
+++ b/include/sys/mman.h
@@ -18,11 +18,11 @@
 #ifndef _MACPORTS_MMAN_H_
 #define _MACPORTS_MMAN_H_
 
-// Include the primary system sys/mman.h
+/* Include the primary system sys/mman.h */
 #include_next <sys/mman.h>
 
-// MAP_ANONYMOUS only exists on 10.11+
-// Prior to that it was called MAP_ANON
+/* MAP_ANONYMOUS only exists on 10.11+ */
+/* Prior to that it was called MAP_ANON */
 #ifndef MAP_ANONYMOUS
 #define MAP_ANONYMOUS MAP_ANON
 #endif

--- a/include/time.h
+++ b/include/time.h
@@ -18,22 +18,22 @@
 #ifndef _MACPORTS_TIME_H_
 #define _MACPORTS_TIME_H_
 
-// Include the primary system time.h
+/* Include the primary system time.h */
 #include_next <time.h>
 
-// MP support header
+/* MP support header */
 #include "MacportsLegacySupport.h"
 
-// Legacy implementation of clock_gettime
+/* Legacy implementation of clock_gettime */
 #if __MP_LEGACY_SUPPORT_GETTIME__
 
 #ifndef CLOCK_REALTIME
-// These values are choosen to match use in macOS10.12+
+/* These values are choosen to match use in macOS10.12+ */
 #define CLOCK_REALTIME             0
 #define CLOCK_MONOTONIC            6
-// we do not implement these (yet).
-//#define CLOCK_MONOTONIC_RAW        4
-//#define CLOCK_MONOTONIC_RAW_APPROX 5
+/* we do not implement these (yet). */
+/* #define CLOCK_MONOTONIC_RAW        4 */
+/* #define CLOCK_MONOTONIC_RAW_APPROX 5 */
 #endif
 
 #ifdef __cplusplus
@@ -47,6 +47,6 @@ extern int clock_getres ( int clk_id, struct timespec *ts );
 }
 #endif
 
-#endif // _MP_LEGACY_SUPPORT_GETTIME__
+#endif /* _MP_LEGACY_SUPPORT_GETTIME__ */
 
-#endif // _MACPORTS_TIME_H_
+#endif /* _MACPORTS_TIME_H_ */

--- a/include/wchar.h
+++ b/include/wchar.h
@@ -18,13 +18,13 @@
 #ifndef _MACPORTS_WCHAR_H_
 #define _MACPORTS_WCHAR_H_
 
-// Include the primary system wchar.h
+/* Include the primary system wchar.h */
 #include_next <wchar.h>
 
-// MP support header
+/* MP support header */
 #include "MacportsLegacySupport.h"
 
-// strnlen
+/* strnlen */
 #if __MP_LEGACY_SUPPORT_WCSDUP__
 #ifdef __cplusplus
 extern "C" {
@@ -35,4 +35,4 @@ extern "C" {
 #endif
 #endif
 
-#endif // _MACPORTS_WCHAR_H_
+#endif /* _MACPORTS_WCHAR_H_ */


### PR DESCRIPTION
suppresses dozens of warning messages for C++ style comments
not being appropriate for older C standards