### PR TITLE
time: add 'clockid_t'

### DIFF
--- a/include/time.h
+++ b/include/time.h
@@ -36,12 +36,19 @@
 /* #define CLOCK_MONOTONIC_RAW_APPROX 5 */
 #endif
 
+/*
+ * Define a type for the above CLOCK_* values; many OSs use 'enum' for
+ * the values & then typedef the enum to 'clockid_t'; use 'int' for
+ * easy compatibility.
+ */
+typedef int clockid_t;
+
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-extern int clock_gettime( int clk_id, struct timespec *ts );
-extern int clock_getres ( int clk_id, struct timespec *ts );
+extern int clock_gettime( clockid_t clk_id, struct timespec *ts );
+extern int clock_getres ( clockid_t clk_id, struct timespec *ts );
   
 #ifdef __cplusplus
 }

--- a/src/time.c
+++ b/src/time.c
@@ -22,7 +22,7 @@
 #include <sys/time.h>
 #include <mach/mach_time.h>
 
-int clock_gettime( int clk_id, struct timespec *ts )
+int clock_gettime( clockid_t clk_id, struct timespec *ts )
 {
   int ret = -1;
   if ( ts )
@@ -48,7 +48,7 @@ int clock_gettime( int clk_id, struct timespec *ts )
   return ret;
 }
 
-int clock_getres ( int clk_id, struct timespec *ts )
+int clock_getres ( clockid_t clk_id, struct timespec *ts )
 {
   int ret = -1;
   if ( ts )


### PR DESCRIPTION
`clockid_t` is the actual type of the first argument to both `clock_*` functions; it might be used by the calling code; just typedef it to be an `int` for easy compatibility. This change works for me to fix building `bladeRF` on OSX 10.5 PPC, which definitely does -not- have the `clock_*` functions.