### PR TITLE
Use __BUILDING_* macros to prevent macro (re)definitions only.

### DIFF
--- a/include/stdlib.h
+++ b/include/stdlib.h
@@ -26,13 +26,13 @@
 /* realpath wrap */
 #if __MP_LEGACY_SUPPORT_REALPATH_WRAP__
 /* we need a way to isolate ourselves from our header wrapping while building */
-#ifndef __BUILDING_MP_LEGACY_SUPPORT_REALPATH_WRAP__
 
+#ifndef __BUILDING_MP_LEGACY_SUPPORT_REALPATH_WRAP__
 /* we are going to move the old realpath definition out of the way */
 #undef realpath
 #define realpath realpath_macports_original
-
 #endif /*__BUILDING_MP_LEGACY_SUPPORT_REALPATH_WRAP__ */
+
 #endif /*__MP_LEGACY_SUPPORT_REALPATH_WRAP__*/
 
 
@@ -42,11 +42,12 @@
 
 /* realpath wrap */
 #if __MP_LEGACY_SUPPORT_REALPATH_WRAP__
-#ifndef __BUILDING_MP_LEGACY_SUPPORT_REALPATH_WRAP__
 
+#ifndef __BUILDING_MP_LEGACY_SUPPORT_REALPATH_WRAP__
 /* and now define realpath as our new wrapped function */
 #undef realpath
 #define realpath macports_legacy_realpath
+#endif /*__BUILDING_MP_LEGACY_SUPPORT_REALPATH_WRAP__ */
 
 #ifdef __cplusplus
 extern "C" {
@@ -55,7 +56,6 @@ extern "C" {
 #ifdef __cplusplus
 }
 #endif
-#endif /*__BUILDING_MP_LEGACY_SUPPORT_REALPATH_WRAP__ */
 #endif /*__MP_LEGACY_SUPPORT_REALPATH_WRAP__*/
 
 

--- a/include/unistd.h
+++ b/include/unistd.h
@@ -3,13 +3,13 @@
 
 
 #if __MP_LEGACY_SUPPORT_SYSCONF_WRAP__
-#ifndef __BUILDING_MP_LEGACY_SUPPORT_SYSCONF_WRAP__
 
+#ifndef __BUILDING_MP_LEGACY_SUPPORT_SYSCONF_WRAP__
 /* redefine the original sysconf */
 #undef sysconf
 #define sysconf sysconf_orig
-
 #endif /* __BUILDING_MP_LEGACY_SUPPORT_SYSCONF_WRAP__ */
+
 #endif /*__MP_LEGACY_SUPPORT_SYSCONF_WRAP__*/
 
 
@@ -19,11 +19,12 @@
 
 
 #if __MP_LEGACY_SUPPORT_SYSCONF_WRAP__
-#ifndef __BUILDING_MP_LEGACY_SUPPORT_SYSCONF_WRAP__
 
+#ifndef __BUILDING_MP_LEGACY_SUPPORT_SYSCONF_WRAP__
 /* and now define sysconf as our new wrapped function */
 #undef sysconf
 #define sysconf macports_legacy_sysconf
+#endif /* __BUILDING_MP_LEGACY_SUPPORT_SYSCONF_WRAP__ */
 
 #ifndef _SC_NPROCESSORS_CONF
 #define _SC_NPROCESSORS_CONF 57
@@ -41,5 +42,4 @@ extern long macports_legacy_sysconf(int);
 }
 #endif
 
-#endif /* __BUILDING_MP_LEGACY_SUPPORT_SYSCONF_WRAP__ */
 #endif /*__MP_LEGACY_SUPPORT_SYSCONF_WRAP__*/

--- a/src/macports_legacy_sysconf.c
+++ b/src/macports_legacy_sysconf.c
@@ -29,15 +29,6 @@
 
 #include <unistd.h>
 
-#ifndef _SC_NPROCESSORS_CONF
-#define _SC_NPROCESSORS_CONF 57
-#endif
-
-#ifndef _SC_NPROCESSORS_ONLN
-#define _SC_NPROCESSORS_ONLN 58
-#endif
-
-
 /* emulate two commonly used but missing selectors from sysconf() on 10.4 */
 
 long macports_legacy_sysconf(int name){


### PR DESCRIPTION
(Repaired version of #9 which cannot be made to look clean by force-pushing)

Regarding the wrapping pattern, I recommend to use the `#ifndef __BUILDING_*` guards only for preventing the macro (re)definitions, nothing else. Firstly because that is their actual purpose, secondly because otherwise that pattern filters out too much, e.g. the definitions of the new `_SC_*` constants (so you have to duplicate them in the `.c` file) and the wrapper function prototype declaration (which prevents the compiler from checking for inconsistencies).

I have also fixed some tab/whitespace issues in `test/test_sysconf.c` along the way.