### PR TITLE
Use asm symbol declarations for wrappers

### DIFF
--- a/include/MacportsLegacySupport.h
+++ b/include/MacportsLegacySupport.h
@@ -20,6 +20,7 @@
 #define _MACPORTS_LEGACYSUPPORTDEFS_H_
 
 #include "AvailabilityMacros.h"
+#include "MacportsLegacyWrappers/wrapper_macros.h"
 
 /* defines for when legacy support is required for various functions */
 
@@ -59,26 +60,20 @@
 /* posix_memalign */
 #define __MP_LEGACY_SUPPORT_POSIX_MEMALIGN__  (__APPLE__ && __ENVIRONMENT_MAC_OS_X_VERSION_MIN_REQUIRED__ < 1060)
 
-/*  realpath() wrap */
-#if (__APPLE__ && __ENVIRONMENT_MAC_OS_X_VERSION_MIN_REQUIRED__ < 1060  \
-               && !defined(__DISABLE_MP_LEGACY_SUPPORT_REALPATH_WRAP__) \
-               && !defined(__DISABLE_ALL_MACPORTS_FUNCTION_WRAPPING__)  )
-# define __MP_LEGACY_SUPPORT_REALPATH_WRAP__ 1
-#else
-# define __MP_LEGACY_SUPPORT_REALPATH_WRAP__ 0
-#endif
+/*  realpath() wrap availability */
+#define __MP_LEGACY_SUPPORT_REALPATH_WRAP__   (__APPLE__ && __ENVIRONMENT_MAC_OS_X_VERSION_MIN_REQUIRED__ < 1060)
+
+/*  realpath() wrap status */
+#define __ENABLE_MP_LEGACY_SUPPORT_REALPATH_WRAP__  (!__DISABLE_MP_LEGACY_SUPPORT_FUNCTION_WRAPPING__  && !__DISABLE_MP_LEGACY_SUPPORT_REALPATH_WRAP__ && __MP_LEGACY_SUPPORT_REALPATH_WRAP__)
 
 /* lsmod */
 #define __MP_LEGACY_SUPPORT_LSMOD__           (__APPLE__ && __ENVIRONMENT_MAC_OS_X_VERSION_MIN_REQUIRED__ < 1050)
 
-/*  sysconf() wrap */
-#if (__APPLE__ && __ENVIRONMENT_MAC_OS_X_VERSION_MIN_REQUIRED__ < 1050 \
-               && !defined(__DISABLE_MP_LEGACY_SUPPORT_SYSCONF_WRAP__) \
-               && !defined(__DISABLE_ALL_MACPORTS_FUNCTION_WRAPPING__) )
-# define __MP_LEGACY_SUPPORT_SYSCONF_WRAP__ 1
-#else
-# define __MP_LEGACY_SUPPORT_SYSCONF_WRAP__ 0
-#endif
+/*  sysconf() wrap availability */
+#define __MP_LEGACY_SUPPORT_SYSCONF_WRAP__    (__APPLE__ && __ENVIRONMENT_MAC_OS_X_VERSION_MIN_REQUIRED__ < 1050)
+
+/*  sysconf() wrap status */
+#define __ENABLE_MP_LEGACY_SUPPORT_SYSCONF_WRAP__  (!__DISABLE_MP_LEGACY_SUPPORT_FUNCTION_WRAPPING__  && !__DISABLE_MP_LEGACY_SUPPORT_SYSCONF_WRAP__ && __MP_LEGACY_SUPPORT_SYSCONF_WRAP__)
  
 /* arc4random */
 #define __MP_LEGACY_SUPPORT_ARC4RANDOM__      (__APPLE__ && __ENVIRONMENT_MAC_OS_X_VERSION_MIN_REQUIRED__ < 1070)

--- a/include/MacportsLegacyWrappers/sysconf_support.h
+++ b/include/MacportsLegacyWrappers/sysconf_support.h
@@ -1,3 +1,4 @@
+
 /*
  * Copyright (c) 2019 Ken Cunningham <kencu@macports.org>
  *
@@ -14,31 +15,13 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  */
 
-/* MP support header */
-#include "MacportsLegacySupport.h"
+/* sysconf macros supported by the macports wrapper */
 
-/* realpath wrap */
-#if __MP_LEGACY_SUPPORT_REALPATH_WRAP__
+#ifndef _SC_NPROCESSORS_CONF
+#define _SC_NPROCESSORS_CONF 57
+#endif
 
-/* we need this blocker so as to not get caught in our own wrap */
-#undef __DISABLE_MP_LEGACY_SUPPORT_REALPATH_WRAP__
-#define __DISABLE_MP_LEGACY_SUPPORT_REALPATH_WRAP__ 1
+#ifndef _SC_NPROCESSORS_ONLN
+#define _SC_NPROCESSORS_ONLN 58
+#endif
 
-#include <limits.h>
-#include <stdlib.h>
-
-char *
-__MP_LEGACY_WRAPPER(realpath)(const char * __restrict stringsearch, char * __restrict buffer)
-{
-    if (buffer == NULL) {
-        char *myrealpathbuf = malloc(PATH_MAX);
-        if (myrealpathbuf != NULL) {
-            return(realpath(stringsearch, myrealpathbuf));
-        } else {
-            return(NULL);
-        }
-    } else {
-        return(realpath(stringsearch, buffer));
-    }
-}
-#endif /*__MP_LEGACY_SUPPORT_REALPATH_WRAP__*/

--- a/include/MacportsLegacyWrappers/wrapper_macros.h
+++ b/include/MacportsLegacyWrappers/wrapper_macros.h
@@ -18,7 +18,7 @@
 #ifndef _MACPORTS_LEGACYSUPPORTWRAP_H_
 #define _MACPORTS_LEGACYSUPPORTWRAP_H_
 
-/* We need support for asm */
+/* We need support for __asm */
 #if !__GNUC__ && !__clang__
 #undef __DISABLE_MP_LEGACY_SUPPORT_FUNCTION_WRAPPING__
 #define __DISABLE_MP_LEGACY_SUPPORT_FUNCTION_WRAPPING__ 1
@@ -26,11 +26,12 @@
 
 #if !__DISABLE_MP_LEGACY_SUPPORT_FUNCTION_WRAPPING__
 /* Could include Darwin's <sys/cdefs.h> and use __STRING, __CONCAT */
-/* But for wrappers we require asm, thus GCC/Clang, thus ANSI C, anyway */
+/* But for wrappers we require __asm, thus GCC/Clang, thus ANSI C, anyway */
 
 /* Wrapper support macros */
+/* Use __asm instead of asm, as the latter is not recognized with e.g. -ansi */
 #define __MP_LEGACY_WRAPPER(sym) macports_legacy_##sym
-#define __MP_LEGACY_WRAPPER_ALIAS(sym) asm("_macports_legacy_" #sym)
+#define __MP_LEGACY_WRAPPER_ALIAS(sym) __asm("_macports_legacy_" #sym)
 
 #endif /* !__DISABLE_MP_LEGACY_SUPPORT_FUNCTION_WRAPPING__ */
 #endif /* _MACPORTS_LEGACYSUPPORTWRAP_H_ */

--- a/include/MacportsLegacyWrappers/wrapper_macros.h
+++ b/include/MacportsLegacyWrappers/wrapper_macros.h
@@ -1,0 +1,36 @@
+
+/*
+ * Copyright (c) 2019 Christian Cornelssen
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
+#ifndef _MACPORTS_LEGACYSUPPORTWRAP_H_
+#define _MACPORTS_LEGACYSUPPORTWRAP_H_
+
+/* We need support for asm */
+#if !__GNUC__ && !__clang__
+#undef __DISABLE_MP_LEGACY_SUPPORT_FUNCTION_WRAPPING__
+#define __DISABLE_MP_LEGACY_SUPPORT_FUNCTION_WRAPPING__ 1
+#endif
+
+#if !__DISABLE_MP_LEGACY_SUPPORT_FUNCTION_WRAPPING__
+/* Could include Darwin's <sys/cdefs.h> and use __STRING, __CONCAT */
+/* But for wrappers we require asm, thus GCC/Clang, thus ANSI C, anyway */
+
+/* Wrapper support macros */
+#define __MP_LEGACY_WRAPPER(sym) macports_legacy_##sym
+#define __MP_LEGACY_WRAPPER_ALIAS(sym) asm("_macports_legacy_" #sym)
+
+#endif /* !__DISABLE_MP_LEGACY_SUPPORT_FUNCTION_WRAPPING__ */
+#endif /* _MACPORTS_LEGACYSUPPORTWRAP_H_ */

--- a/include/stdlib.h
+++ b/include/stdlib.h
@@ -23,33 +23,33 @@
 #include "MacportsLegacySupport.h"
 
 /* realpath wrap */
-#if __MP_LEGACY_SUPPORT_REALPATH_WRAP__
+#if __ENABLE_MP_LEGACY_SUPPORT_REALPATH_WRAP__
 
 /* we are going to move the old realpath definition out of the way */
 #undef realpath
 #define realpath(a,b) realpath_macports_original(a,b)
 
-#endif /*__MP_LEGACY_SUPPORT_REALPATH_WRAP__*/
+#endif /*__ENABLE_MP_LEGACY_SUPPORT_REALPATH_WRAP__*/
 
 /* Include the primary system stdlib.h */
 #include_next <stdlib.h>
 
 /* realpath wrap */
-#if __MP_LEGACY_SUPPORT_REALPATH_WRAP__
+#if __ENABLE_MP_LEGACY_SUPPORT_REALPATH_WRAP__
 
 /* and now define realpath as our new wrapped function */
 #undef realpath
-#define realpath(a,b) macports_legacy_realpath(a,b)
 
 #ifdef __cplusplus
 extern "C" {
 #endif
-  extern char * macports_legacy_realpath(const char * __restrict, char * __restrict);
+  extern char *realpath(const char * __restrict, char * __restrict)
+               __MP_LEGACY_WRAPPER_ALIAS(realpath);
 #ifdef __cplusplus
 }
 #endif
 
-#endif /*__MP_LEGACY_SUPPORT_REALPATH_WRAP__*/
+#endif /*__ENABLE_MP_LEGACY_SUPPORT_REALPATH_WRAP__*/
 
 /* posix_memalign */
 #if __MP_LEGACY_SUPPORT_POSIX_MEMALIGN__

--- a/include/unistd.h
+++ b/include/unistd.h
@@ -2,13 +2,13 @@
 #include "MacportsLegacySupport.h"
 
 
-#if __MP_LEGACY_SUPPORT_SYSCONF_WRAP__
+#if __ENABLE_MP_LEGACY_SUPPORT_SYSCONF_WRAP__
 
 /* redefine the original sysconf */
 #undef sysconf
 #define sysconf(a) sysconf_orig(a)
 
-#endif /*__MP_LEGACY_SUPPORT_SYSCONF_WRAP__*/
+#endif /*__ENABLE_MP_LEGACY_SUPPORT_SYSCONF_WRAP__*/
 
 
 
@@ -16,26 +16,18 @@
 
 
 
-#if __MP_LEGACY_SUPPORT_SYSCONF_WRAP__
+#if __ENABLE_MP_LEGACY_SUPPORT_SYSCONF_WRAP__
 
 /* and now define sysconf as our new wrapped function */
 #undef sysconf
-#define sysconf(a) macports_legacy_sysconf(a)
-
-#ifndef _SC_NPROCESSORS_CONF
-#define _SC_NPROCESSORS_CONF 57
-#endif
-
-#ifndef _SC_NPROCESSORS_ONLN
-#define _SC_NPROCESSORS_ONLN 58
-#endif
+#include "MacportsLegacyWrappers/sysconf_support.h"
 
 #ifdef __cplusplus
 extern "C" {
 #endif
-extern long macports_legacy_sysconf(int);
+extern long sysconf(int) __MP_LEGACY_WRAPPER_ALIAS(sysconf);
 #ifdef __cplusplus
 }
 #endif
 
-#endif /*__MP_LEGACY_SUPPORT_SYSCONF_WRAP__*/
+#endif /* __ENABLE_MP_LEGACY_SUPPORT_SYSCONF_WRAP__ */

--- a/src/macports_legacy_sysconf.c
+++ b/src/macports_legacy_sysconf.c
@@ -21,8 +21,8 @@
 #if __MP_LEGACY_SUPPORT_SYSCONF_WRAP__
 
 /* we need this blocker so as to not get caught in our own wrap */
-#undef  __MP_LEGACY_SUPPORT_SYSCONF_WRAP__
-#define __DISABLE_MP_LEGACY_SUPPORT_SYSCONF_WRAP__
+#undef __DISABLE_MP_LEGACY_SUPPORT_SYSCONF_WRAP__
+#define __DISABLE_MP_LEGACY_SUPPORT_SYSCONF_WRAP__ 1
 
 
 #include <sys/types.h>
@@ -30,18 +30,11 @@
 
 #include <unistd.h>
 
-#ifndef _SC_NPROCESSORS_CONF
-#define _SC_NPROCESSORS_CONF 57
-#endif
-
-#ifndef _SC_NPROCESSORS_ONLN
-#define _SC_NPROCESSORS_ONLN 58
-#endif
-
-
 /* emulate two commonly used but missing selectors from sysconf() on 10.4 */
 
-long macports_legacy_sysconf(int name){
+#include <MacportsLegacyWrappers/sysconf_support.h>
+
+long __MP_LEGACY_WRAPPER(sysconf)(int name){
 
     if ( name == _SC_NPROCESSORS_ONLN ) {
 
@@ -55,7 +48,7 @@ long macports_legacy_sysconf(int name){
 
         if (ret < 0 || count < 1) {
             /* try again with _SC_NPROCESSORS_CONF */
-            return macports_legacy_sysconf(_SC_NPROCESSORS_CONF);
+            return __MP_LEGACY_WRAPPER(sysconf)(_SC_NPROCESSORS_CONF);
         } else {
             return (long)count;
         }

--- a/test/test_realpath.c
+++ b/test/test_realpath.c
@@ -15,14 +15,61 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  */
 
+/*
+ * Deliberately declaring some potentially redefined names
+ * before including the associated header file, to test robustness.
+ */
+
+/* Wrapper should work not only with calls, but with references as well */
+/* __restrict not needed here (and remember: nothing included yet) */
+typedef char * (*strfunc_t)(const char *, char *);
+
+/* Renaming different objects should not affect functionality */
+typedef struct { char *realpath; } rpv_t;
+typedef struct { strfunc_t realpath; } rpf_t;
+
 #include <stdlib.h>
 #include <stdio.h>
+#include <string.h>
+#include <assert.h>
 
 int main() {
+    /* Test with direct function call */
     const char *p = realpath(".", NULL);	/* bus error up to 10.5 */
     if (!p) return 1;
-    printf("%s\n", p);
-    printf("realpath supports NULL pointer\n");
+    printf("cwd = %s\n", p);
+    printf("realpath(path, NULL) supported.\n");
+
+    /* Test with name (reference) only */
+    {
+        strfunc_t f = realpath;
+        const char *q = f(".", NULL);
+        if (!q) return 1;
+        assert (!strcmp(q, p));
+        printf("f = realpath, f(path, NULL) supported.\n");
+        free((void*)q);
+    }
+
+    /* Test with function macro disabler */
+    {
+        const char *q = (realpath)(".", NULL);
+        if (!q) return 1;
+        assert (!strcmp(q, p));
+        printf("(realpath)(path, NULL) supported.\n");
+        free((void*)q);
+    }
+
+    /* Test with same-named fields */
+    {
+        rpf_t rpf = { realpath };
+	rpv_t rpv;
+        rpv.realpath = rpf.realpath(".", NULL);
+        if (!rpv.realpath) return 1;
+        assert (!strcmp(rpv.realpath, p));
+        printf("rpv.realpath = rpf.realpath(path, NULL) supported.\n");
+        free((void*)rpv.realpath);
+    }
+
     free((void*)p);
     return 0;
 }


### PR DESCRIPTION
The idea is taken from Apple's own declaration of `realpath`: It boils down to

    extern char *realpath(const char * __restrict, char * __restrict)
                 asm("_linker_symbol_for_realpath");

This means that we do not need to use macros for renaming symbols (except for temporarily moving the original declaration out of the way). The compiler does that for us where necessary (and only there). This preserves source-level API compatibility.

Take a look at `test/test_{realpath,sysconf}.c` for the scenarios tested. Some of those are close to existing practice, as `libuv` shows.

This pull request

* Uses opt-out (`__DISABLE_...` macros) again (in contrast to the [ccorn:globaldefs](https://github.com/ccorn/macports-legacy-support/tree/globaldefs) branch). As that approach is good enough for Apple's system `realpath`, it should be good enough for us as well.
* Uses `__ENABLE_...` macros for wrappers but defines those in terms of the respective availability macros and `__DISABLE_...` macros.
* `MacportsLegacySupport.h` is straightforward again; `__MP_LEGACY_SUPPORT_XXX_WRAP__` are defined independently from their `__ENABLE_...` and `__DISABLE_...` cousins. In other words, `__MP_LEGACY_SUPPORT_..._WRAP__` indicates *availability* of a wrapper, not its *activation*. The latter is given by the `__ENABLE_...` macro.
* Uses `__DISABLE_MP_LEGACY_SUPPORT_FUNCTION_WRAPPING__` instead of `defined(__DISABLE_ALL_MACPORTS_FUNCTION_WRAPPING__)`
* `__ENABLE_...` and `__DISABLE_...` are to be queried with `#if` now, not with `#ifdef`. Note that after macro expansion in `#if` conditions, the preprocessor replaces leftover identifiers with `0`, so you do not need to predefine those macros. Note also that the `cc` option `-Dname` is a shorthand for `-Dname=1`; no need to be verbose there either.
* Uses an additional header `MacportsLegacyWrappers/sysconf_support.h` for the additional `_SC_...` macros. That avoids the need for duplicate definitions. Including `<unistd.h>` will only define the additional macros if the wrapper is enabled.
* Uses macros `__MP_LEGACY_WRAPPER` and `__MP_LEGACY_WRAPPER_ALIAS` to avoid hardcoding the use of `macports_legacy_` everywhere. That may be a bit over-engineered, and tools like `ctags` might get confused from the use of macros in function names.
* Defines the above wrapper helper macros in `include/MacportsLegacyWrappers/wrapper_macros.h`. Currently I simply include that from `include/MacportsLegacySupport.h`, but if you are afraid about unneeded macros, we could include it instead from the four headers and source files that actually need it.
