### PR TITLE
Tiger: add PTHREAD_RWLOCK_INITIALIZER

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ via the legacysupport PortGroup.
 Wrapped headers are:
 
  - cmath         : Adds declaration of various `long long` methods missing in OSX10.6 and older.
+ - pthread.h     : Adds PTHREAD_RWLOCK_INITIALIZER for OSX10.4
  - stdio.h       : Adds `getline` and `getdelim` functions missing in OSX10.6 and older.
  - stdlib.h      : Adds `posix_memalign` functional replacement,
                    and wraps `realpath` to accept a NULL buffer argument,

--- a/include/MacportsLegacySupport.h
+++ b/include/MacportsLegacySupport.h
@@ -78,4 +78,8 @@
 /* arc4random */
 #define __MP_LEGACY_SUPPORT_ARC4RANDOM__      (__APPLE__ && __ENVIRONMENT_MAC_OS_X_VERSION_MIN_REQUIRED__ < 1070)
 
+/* pthread_rwlock_initializer */
+#define __MP_LEGACY_SUPPORT_PTHREAD_RWLOCK__  (__APPLE__ && __ENVIRONMENT_MAC_OS_X_VERSION_MIN_REQUIRED__ < 1050)
+
+
 #endif /* _MACPORTS_LEGACYSUPPORTDEFS_H_ */

--- a/include/pthread.h
+++ b/include/pthread.h
@@ -1,0 +1,38 @@
+
+/*
+ * Copyright (c) 2018 Ken Cunningham <kencu@macports.org>
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
+#ifndef _MACPORTS_PTHREAD_H_
+#define _MACPORTS_PTHREAD_H_
+
+
+
+/* Include the primary system pthread.h */
+#include_next <pthread.h>
+
+/* MP support header */
+#include "MacportsLegacySupport.h"
+
+
+#if __MP_LEGACY_SUPPORT_PTHREAD_RWLOCK__ 
+/* PTHREAD_RWLOCK_INITIALIZER is not defined on Tiger */
+#ifndef PTHREAD_RWLOCK_INITIALIZER
+#define PTHREAD_RWLOCK_INITIALIZER {_PTHREAD_RWLOCK_SIG_init, {0}}
+#endif
+#endif /* __MP_LEGACY_SUPPORT_PTHREAD_RWLOCK__  */
+
+
+#endif /* _MACPORTS_PTHREAD_H_ */

--- a/include/pthread_impl.h
+++ b/include/pthread_impl.h
@@ -1,0 +1,38 @@
+
+/*
+ * Copyright (c) 2018 Ken Cunningham <kencu@macports.org>
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
+#ifndef _MACPORTS_PTHREAD_IMPL_H_
+#define _MACPORTS_PTHREAD_IMPL_H_
+
+
+
+/* Include the primary system pthread_impl.h */
+#include_next <pthread_impl.h>
+
+/* MP support header */
+#include "MacportsLegacySupport.h"
+
+
+#if __MP_LEGACY_SUPPORT_PTHREAD_RWLOCK__ 
+/* PTHREAD_RWLOCK_INITIALIZER is not defined on Tiger */
+#ifndef _PTHREAD_RWLOCK_SIG_init
+#define _PTHREAD_RWLOCK_SIG_init    0x2DA8B3B4
+#endif
+#endif /* __MP_LEGACY_SUPPORT_PTHREAD_RWLOCK__  */
+
+
+#endif /* _MACPORTS_PTHREAD_IMPL_H_ */

--- a/test/test_pthread_rwlock_basic.c
+++ b/test/test_pthread_rwlock_basic.c
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2019 Ken Cunningham <kencu@macports.org>
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
+#include <stdio.h>
+#include <pthread.h>
+
+int
+main (void)
+{
+    printf("\nTesting PTHREAD_RWLOCK_INITIALIZER\n");
+    pthread_rwlock_t  aLock = PTHREAD_RWLOCK_INITIALIZER;
+    pthread_rwlock_rdlock(&aLock);
+    pthread_rwlock_unlock(&aLock);
+    pthread_rwlock_destroy(&aLock);
+    printf("Success testing PTHREAD_RWLOCK_INITIALIZER\n\n");
+
+    printf("Testing pthread_rwlock_init\n");
+    pthread_rwlock_t  myLock;
+    pthread_rwlock_init(&myLock, NULL);
+    pthread_rwlock_rdlock(&myLock);
+    pthread_rwlock_unlock(&myLock);
+    pthread_rwlock_destroy(&myLock);
+    printf("Success testing pthread_rwlock_init\n\n");
+    
+    return 0;
+}


### PR DESCRIPTION
this is a commonly used macro missing from Tiger
tested using the basic test here, and also using
the more detailed test from
Richard Stevens' Unix Network Programming Vol 2 Second Ed
Source here: https://www.kohala.com/start/unpv22e/unpv22e.html
in my_rwlock/test1.c