### PR TITLE
Create fdopendir variations (including ground work for multiple variations support)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,6 +49,7 @@ LD              ?= ld
 LDFLAGS         ?=
 AR              ?= ar
 UNAME           ?= /usr/bin/uname
+SED             ?= /usr/bin/sed
 
 MKINSTALLDIRS    = install -d -m 755
 INSTALL_PROGRAM  = install -c -m 755

--- a/Makefile
+++ b/Makefile
@@ -52,6 +52,7 @@ AR              ?= ar
 UNAME           ?= /usr/bin/uname
 SED             ?= /usr/bin/sed
 GREP            ?= /usr/bin/grep
+CP              ?= /bin/cp
 
 MKINSTALLDIRS    = install -d -m 755
 INSTALL_PROGRAM  = install -c -m 755

--- a/Makefile
+++ b/Makefile
@@ -48,6 +48,7 @@ CXXFLAGS        ?= -Os -Wall
 LD              ?= ld
 LDFLAGS         ?=
 AR              ?= ar
+UNAME           ?= /usr/bin/uname
 
 MKINSTALLDIRS    = install -d -m 755
 INSTALL_PROGRAM  = install -c -m 755

--- a/Makefile
+++ b/Makefile
@@ -48,8 +48,10 @@ CXXFLAGS        ?= -Os -Wall
 LD              ?= ld
 LDFLAGS         ?=
 AR              ?= ar
+
 UNAME           ?= /usr/bin/uname
 SED             ?= /usr/bin/sed
+GREP            ?= /usr/bin/grep
 
 MKINSTALLDIRS    = install -d -m 755
 INSTALL_PROGRAM  = install -c -m 755

--- a/Makefile
+++ b/Makefile
@@ -37,6 +37,7 @@ BUILDSLIBFLAGS   = -qs
 POSTINSTALL      = install_name_tool
 POSTINSTALLFLAGS = -id $(DLIBPATH)
 
+FORCE_ARCH      ?=
 ARCHFLAGS       ?=
 LIPO            ?= lipo
 CC              ?= cc $(ARCHFLAGS)

--- a/Makefile
+++ b/Makefile
@@ -44,6 +44,7 @@ DLIBCFLAGS      ?= -fPIC
 SLIBCFLAGS      ?=
 CXX             ?= c++ $(ARCHFLAGS)
 CXXFLAGS        ?= -Os -Wall
+LD              ?= ld
 LDFLAGS         ?=
 AR              ?= ar
 

--- a/Makefile
+++ b/Makefile
@@ -60,6 +60,8 @@ INSTALL_DATA     = install -c -m 644
 RM               = rm -f
 RMDIR            = sh -c 'for d; do test ! -d "$$d" || rmdir -p "$$d"; done' rmdir
 
+PLATFORM        ?= $(shell $(UNAME) -r | $(SED) -ne 's/\([0-9][0-9]*\)\..*/\1/p')
+
 SRCDIR           = src
 SRCINCDIR        = include
 # Use VAR := $(shell CMD) instead of VAR != CMD to support old make versions

--- a/Makefile
+++ b/Makefile
@@ -90,6 +90,104 @@ TESTPRGS_CPP    := $(patsubst %.cpp,%,$(TESTSRCS_CPP))
 TESTPRGS         = $(TESTPRGS_C) $(TESTPRGS_CPP)
 TESTRUNS        := $(patsubst $(TESTNAMEPREFIX)%,$(TESTRUNPREFIX)%,$(TESTPRGS))
 
+define splitandfilterandmergemultiarch
+	output='$(1)' && \
+	lipo='$(2)' && \
+	rm='$(3)' && \
+	cp='$(4)' && \
+	ld='$(5)' && \
+	grep='$(6)' && \
+	platform='$(7)' && \
+	force_arch='$(8)' && \
+	objectlist="$${output}".* && \
+	archlist='' && \
+	fatness='' && \
+	for object in $${objectlist}; do \
+		if [ -z "$${force_arch}" ]; then \
+			archlist_new="$$($${lipo} -archs "$${object}")"; \
+		else \
+			archlist_new="$${force_arch}"; \
+		fi && \
+		if [ -n "$${archlist}" ] && [ "$${archlist}" != "$${archlist_new}" ]; then \
+			printf 'Old/previous architecture list "%s" does not match new one "%s", this is unsupported.\n' "$${archlist}" "$${archlist_new}" >&2 && \
+			exit '1'; \
+		else \
+			archlist="$${archlist_new}"; \
+		fi && \
+		( $${lipo} -info "$${object}" | grep -qs '^Non-fat file:' ); \
+		fatness_new="$${?}" && \
+		if [ -n "$${fatness}" ] && [ "$${fatness}" != "$${fatness_new}" ]; then \
+			printf 'Old/previous fatness value "%d" does not match new one "%d", this is unsupported.\n' "$${fatness}" "$${fatness_new}" >&2 && \
+			exit '2'; \
+		else \
+			fatness="$${fatness_new}"; \
+		fi && \
+		if [ -n "$${force_arch}" ] && [ '0' -ne "$${fatness}" ]; then \
+			printf 'Architecture forced to "%s", but object file "%s" is a multi-architecture (fat) object file, this is unsupported.\n' "$${force_arch}" "$${object}" >&2 && \
+			exit '3'; \
+		fi && \
+		$$(: 'Check for unknown architectures.') && \
+		for arch in $${archlist}; do \
+			case "$${arch}" in \
+				(unknown*) \
+					printf 'Unknown architecture "%s" encountered, this is unsupported.\n' "$${arch}" >&2 && \
+					exit '4'; \
+					;; \
+				(*) \
+					;; \
+			esac && \
+			if [ '0' -eq "$${fatness}" ]; then \
+				$${cp} "$${object}" "$${object}.$${arch}" && \
+				$$(: 'A non-fat file cannot have more than one architecture, but breaking out sounds weird.'); \
+			else \
+				$${lipo} "$${object}" -thin "$${arch}" -output "$${object}.$${arch}"; \
+			fi; \
+		done && \
+		$${rm} "$${object}"; \
+	done && \
+	$$(: '... and use ld to merge each variant into a single-architecture object file ...') && \
+	for arch in $${archlist}; do \
+		$$(: 'Filter out variants not applicable to certain architectures.') && \
+		$$(: 'For instance, the x86_64 architecture is fully UNIX2003-compliant and thus does not have $$UNIX2003-compat functons.') && \
+		$$(: 'On the contrary, the i386 architecture has only $$UNIX2003-compat functions for the $$INODE64 feature set.') && \
+		$$(: '10.4 is so old that it does not even have the $$INODE64 feature.') && \
+		case "$${arch}" in \
+			('x86_64') \
+				$${ld} -r "$${output}.inode32.$${arch}" "$${output}.inode64.$${arch}" -o "$${output}.$${arch}"; \
+				;; \
+			('ppc64') \
+				if [ '9' -gt "$${platform}" ]; then \
+					$${ld} -r "$${output}.inode32.$${arch}" -o "$${output}.$${arch}"; \
+				else \
+					$${ld} -r "$${output}.inode32.$${arch}" "$${output}.inode64.$${arch}" -o "$${output}.$${arch}"; \
+				fi; \
+				;; \
+			('i386'|'ppc') \
+				if [ '9' -gt "$${platform}" ]; then \
+					$${ld} -r "$${output}.inode32.$${arch}" "$${output}.inode32unix2003.$${arch}" -o "$${output}.$${arch}"; \
+				else \
+					$${ld} -r "$${output}.inode32.$${arch}" "$${output}.inode32unix2003.$${arch}" "$${output}.inode64unix2003.$${arch}" -o "$${output}.$${arch}"; \
+				fi; \
+				;; \
+			(*) \
+				$${ld} -r "$${output}.inode32.$${arch}" "$${output}.inode32unix2003.$${arch}" "$${output}.inode64.$${arch}" "$${output}.inode64unix2003.$${arch}" -o "$${output}.$${arch}"; \
+				;; \
+		esac; \
+	done && \
+	$$(: '... build list of single-architecture merged object files ...') && \
+	objectarchlist='' && \
+	for arch in $${archlist}; do \
+		objectarchlist="$${objectarchlist} $${output}.$${arch}"; \
+	done && \
+	if [ '0' -eq "$${fatness}" ]; then \
+		$$(: 'Thin files can just be copied directly, assuming that the list will only contain one element.') && \
+		$${cp} $${objectarchlist} "$${output}"; \
+	else \
+		$$(: '... and eventually use lipo to merge them all together!') && \
+		$${lipo} $${objectarchlist} -create -output "$${output}"; \
+	fi
+endef
+
 all: dlib slib
 dlib: $(BUILDDLIBPATH)
 slib: $(BUILDSLIBPATH)

--- a/Makefile
+++ b/Makefile
@@ -38,6 +38,7 @@ POSTINSTALL      = install_name_tool
 POSTINSTALLFLAGS = -id $(DLIBPATH)
 
 ARCHFLAGS       ?=
+LIPO            ?= lipo
 CC              ?= cc $(ARCHFLAGS)
 CFLAGS          ?= -Os -Wall
 DLIBCFLAGS      ?= -fPIC

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # MacPorts Support for Legacy OSX Versions
 
+## Features
+
 Installs a number of wrapper headers around system headers that add
 functionality missing in various older OSX releases.
 
@@ -130,3 +132,56 @@ Wrapped headers are:
     <td>OSX10.10</td>
   </tr>
 </table>
+
+## Building
+
+This project does currently *not* use a configuration phase.
+
+Instead, configuration is supposed to take place by overriding the main
+`Makefile`'s variables, either via environment variables, command line
+parameters to the `make` call itself or modification of the main `Makefile`.
+
+`GNU make` is a hard build dependency.
+
+Most variables contain paths to various tools. Unless explicitly stated
+otherwise, both system (BSD-derived) and `GNU coreutils` variants should work,
+with a preference for the native system tools.
+
+### Special variables
+
+#### `PLATFORM`
+
+Major Darwin (not [Mac] OS X/macOS!) version to target against.
+
+This is typically detected automatically, but can also be overridden manually
+to test builds for other OS versions.
+
+Some symbols must be built multiple times. Each variant will use a different
+data layout and have a special postfix appended to it. The data layouts
+supported and needed depend upon the architecture and (target) OS version.
+
+#### `FORCE_ARCH`
+
+Exactly one single architecture to build for.
+
+Older versions of `lipo` do not support the `-archs` flag, so automatic
+architecture detection via binary/object file inspection will *not* be possible
+on older platforms.
+
+In order to avoid an additional dependency, and, arguably more importantly, a
+circular dependency with the `cctools` port providing newer `lipo` versions
+within `MacPorts`, this variable was introduced. It disables the automatic
+architecture detection feature and instead hardcodes the contained value as the
+target architecture.
+
+Within `MacPorts`, we use it in universal (multi-architecture) builds with one
+pass per architecture. Eventually, the `MacPorts` system/`muniversal` PortGroup
+will merge the resulting binaries into one fat/universal binary automatically.
+
+**This variable takes one single value only. It is not a list.**
+
+If your `lipo` binary is new enough and supports the `-archs` flag, you will
+*not* need to use this variable. Instead, directly build the software
+universally in one pass via the usual `-arch` compiler flags. The
+autodetection, split and merge features will then handle the different
+architectures automatically.

--- a/include/dirent.h
+++ b/include/dirent.h
@@ -27,7 +27,7 @@
 /* fdopendir */
 #if __MP_LEGACY_SUPPORT_FDOPENDIR__
 __MP__BEGIN_DECLS
-extern DIR *fdopendir(int fd);
+extern DIR *fdopendir(int fd) __DARWIN_ALIAS_I(fdopendir);
 __MP__END_DECLS
 #endif
 

--- a/src/fdopendir.c
+++ b/src/fdopendir.c
@@ -31,7 +31,7 @@
 # define SYS___pthread_fchdir 349
 #endif
 
-int best_fchdir(int dirfd)
+static int best_fchdir(int dirfd)
 {
 #if __ENVIRONMENT_MAC_OS_X_VERSION_MIN_REQUIRED__ >= 1050
   return syscall(SYS___pthread_fchdir, dirfd);


### PR DESCRIPTION
This PR included support for building multiple variations of specific symbols.

Currently, it only does that for `fdopendir`. One consumer of this are newer versions of `go`, but you already know that.

We will probably need to eventually do this for other `atcalls` as well, but I'm too lazy to check which ones are necessary and refactor (split out) the code to do that. The good part is that this operation should be pretty easy to do, since this PR lays a solid foundation for this sort of things.

Also, documentation is added for this new feature (plus a bit of more general documentation that was missing).

Once this is merged, I will update the `legacy-support-devel` port to the new build procedure.