### PR TITLE
which: exit 1 when the file is not found

### DIFF
--- a/tiger_only/bin/which
+++ b/tiger_only/bin/which
@@ -71,5 +71,7 @@ foreach arg ( $argv )
     endif
     if ( ! $?found ) then
 #MACPORTS_EDIT echo no $arg in $path
+# exit 1 just like any modern which implementation
+        exit 1
     endif
 end


### PR DESCRIPTION
allows for constructs like
$ which tool || which toolalternative