### PR TITLE
getattrlistat - Use void* instead of struct attrlist*

### DIFF
--- a/include/sys/unistd.h
+++ b/include/sys/unistd.h
@@ -53,7 +53,7 @@ typedef __darwin_gid_t		gid_t;
 
 __MP__BEGIN_DECLS
 
-extern int getattrlistat(int dirfd, const char *pathname, struct attrlist *a,
+extern int getattrlistat(int dirfd, const char *pathname, void *a,
 			 void *buf, size_t size, unsigned long flags);
 extern ssize_t readlinkat(int dirfd, const char *pathname, char *buf, size_t bufsiz);
 extern int faccessat(int dirfd, const char *pathname, int mode, int flags);

--- a/src/atcalls.c
+++ b/src/atcalls.c
@@ -211,8 +211,8 @@ int fstatat64(int dirfd, const char *pathname, struct stat64 *buf, int flags)
 }
 #endif
 
-int getattrlistat(int dirfd, const char *pathname, struct attrlist *a,
-                                 void *buf, size_t size, unsigned long flags)
+int getattrlistat(int dirfd, const char *pathname, void *a,
+                  void *buf, size_t size, unsigned long flags)
 {
 #ifdef __LP64__
     /* This is fricken stupid */


### PR DESCRIPTION
Triggered by discussion at 

https://github.com/macports/macports-ports/commit/78b2cb450f7f56f0d1e6f66c44cd6e3a3fd742b1

Scanning through the API for `getatrlistat` in various OSX versions it turns out the API is slightly different to what we have here. Basically one argument is `void*` and not a specific type.  e.g. from macOS (10.15)

```
int     getattrlistat(int, const char *, void *, void *, size_t, unsigned long) __OSX_AVAILABLE_STARTING(__MAC_10_10, __IPHONE_8_0);
```

This MR just updates the API to match.

@kencu FYI