### PR TITLE
Add implementations for ffsl (<10.5) and ffsll (<10.9)

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,11 @@ Wrapped headers are:
     <td>OSX10.6</td>
   </tr>
   <tr>
+    <td><code>strings.h</code></td>
+    <td>Adds <code>ffsl</code>(OSX10.4) and <code>ffsll</code>(macOS10.8) functions</td>
+    <td>OSX10.6(8)</td>
+  </tr>
+  <tr>
     <td><code>time.h</code></td>
     <td>Adds <code>clock_gettime</code> function</td>
     <td>OSX10.11</td>

--- a/include/MacportsLegacySupport.h
+++ b/include/MacportsLegacySupport.h
@@ -116,7 +116,13 @@
 #define __MP_LEGACY_SUPPORT_CXX11_CMATH__ 0
 #endif
 
-/* STAILQ_FOREACH is not defined on Tiger*/
+/* cossin */
 #define __MP_LEGACY_SUPPORT_COSSIN__  (__APPLE__ && __ENVIRONMENT_MAC_OS_X_VERSION_MIN_REQUIRED__ < 1090)
+
+/* ffsll */
+#define __MP_LEGACY_SUPPORT_FFSLL__           (__APPLE__ && __ENVIRONMENT_MAC_OS_X_VERSION_MIN_REQUIRED__ < 1090)
+
+/* ffsl */
+#define __MP_LEGACY_SUPPORT_FFSL__            (__APPLE__ && __ENVIRONMENT_MAC_OS_X_VERSION_MIN_REQUIRED__ < 1050)
 
 #endif /* _MACPORTS_LEGACYSUPPORTDEFS_H_ */

--- a/include/strings.h
+++ b/include/strings.h
@@ -1,0 +1,41 @@
+
+/*
+ * Copyright (c) 2018 Chris Jones <jonesc@macports.org>
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
+#ifndef _MACPORTS_STRINGS_H_
+#define _MACPORTS_STRINGS_H_
+
+/* MP support header */
+#include "MacportsLegacySupport.h"
+
+/* Include the primary system string.h */
+#include_next <strings.h>
+
+/* ffsll */
+#if __MP_LEGACY_SUPPORT_FFSLL__
+__MP__BEGIN_DECLS
+extern int ffsll(long long int);
+__MP__END_DECLS
+#endif
+
+/* ffsl */
+#if __MP_LEGACY_SUPPORT_FFSL__
+__MP__BEGIN_DECLS
+extern int ffsl(long int);
+__MP__END_DECLS
+#endif
+
+#endif /* _MACPORTS_STRINGS_H_ */

--- a/src/strings.c
+++ b/src/strings.c
@@ -1,0 +1,58 @@
+
+/*-
+ * Copyright (c) 1990, 1993
+ *	The Regents of the University of California.  All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the University nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE REGENTS AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE REGENTS OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ */
+
+// MP support header
+#include "MacportsLegacySupport.h"
+
+#if __MP_LEGACY_SUPPORT_FFSLL__
+int ffsll(long long mask)
+{
+  int bit = 0;
+  if (mask != 0) {
+    for (bit = 1; !(mask & 1); bit++) {
+      mask = (unsigned long long)mask >> 1;
+    }
+  }
+  return (bit);
+}
+#endif
+
+#if __MP_LEGACY_SUPPORT_FFSL__
+int ffsl(long mask)
+{
+  int bit = 0;
+  if (mask != 0) {
+    for (bit = 1; !(mask & 1); bit++) {
+      mask = (unsigned long)mask >> 1;
+    }
+  }
+  return (bit);
+}
+#endif

--- a/test/test_ffsl.c
+++ b/test/test_ffsl.c
@@ -1,0 +1,39 @@
+
+/*
+ * Copyright (c) 2019 Chris Jones
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
+#include <stdio.h>
+#include <strings.h>
+
+int main() {
+
+  printf( "testing ffsl :-\n" );
+  for ( int i = 0; i <= 32; ++i ) {
+    const long int test = ( i>0 ? 1UL << i-1 : 0);
+    const int j = ffsl(test);
+    printf( "  Set bit %i - Found bit %i\n", i, j );
+  }
+
+  printf( "testing ffsll :-\n" );
+  for ( int i = 0; i <= 64; ++i ) {
+    const long long int test = ( i>0 ? 1UL << i-1 : 0 );
+    const int j = ffsll(test);
+    printf( "  Set bit %i - Found bit %i\n", i, j );
+  }
+  
+  return 0;
+}
+


### PR DESCRIPTION
@kencu FYI. Stumbled over these via the new `Alembic` port

https://build.macports.org/builders/ports-10.6_x86_64-builder/builds/27179/steps/install-port/logs/stdio

Availability is

```
Oberon /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include > grep ffs strings.h
int	 ffs(int);
int	 ffsl(long) __OSX_AVAILABLE_STARTING(__MAC_10_5, __IPHONE_2_0);
int	 ffsll(long long) __OSX_AVAILABLE_STARTING(__MAC_10_9, __IPHONE_7_0);
```