### PR TITLE
include: support undefined wrapping macros.

### DIFF
--- a/include/MacportsLegacySupport.h
+++ b/include/MacportsLegacySupport.h
@@ -92,8 +92,8 @@
 #define __MP_LEGACY_SUPPORT_REALPATH_WRAP__   (__APPLE__ && __ENVIRONMENT_MAC_OS_X_VERSION_MIN_REQUIRED__ < 1060)
 
 /*  realpath() wrap has bail-out macros in case we want to disable only function wrapping */
-#define __ENABLE_MP_LEGACY_SUPPORT_REALPATH_WRAP__  (!__DISABLE_MP_LEGACY_SUPPORT_FUNCTION_WRAPPING__  && \
-						     !__DISABLE_MP_LEGACY_SUPPORT_REALPATH_WRAP__      && \
+#define __ENABLE_MP_LEGACY_SUPPORT_REALPATH_WRAP__  ((!defined (__DISABLE_MP_LEGACY_SUPPORT_FUNCTION_WRAPPING__) || !__DISABLE_MP_LEGACY_SUPPORT_FUNCTION_WRAPPING__)  && \
+						     (!defined (__DISABLE_MP_LEGACY_SUPPORT_REALPATH_WRAP__) || !__DISABLE_MP_LEGACY_SUPPORT_REALPATH_WRAP__)          && \
 						     __MP_LEGACY_SUPPORT_REALPATH_WRAP__)
 
 /* lsmod does not exist on Tiger */
@@ -109,8 +109,8 @@
 #define __MP_LEGACY_SUPPORT_SYSCONF_WRAP__    (__APPLE__ && __ENVIRONMENT_MAC_OS_X_VERSION_MIN_REQUIRED__ < 101100)
 
 /*  sysconf() wrap has bail-out macros in case we want to disable only function wrapping */
-#define __ENABLE_MP_LEGACY_SUPPORT_SYSCONF_WRAP__  (!__DISABLE_MP_LEGACY_SUPPORT_FUNCTION_WRAPPING__  && \
-						    !__DISABLE_MP_LEGACY_SUPPORT_SYSCONF_WRAP__       && \
+#define __ENABLE_MP_LEGACY_SUPPORT_SYSCONF_WRAP__  ((!defined (__DISABLE_MP_LEGACY_SUPPORT_FUNCTION_WRAPPING__) || !__DISABLE_MP_LEGACY_SUPPORT_FUNCTION_WRAPPING__)  && \
+						    (!defined (__DISABLE_MP_LEGACY_SUPPORT_SYSCONF_WRAP__) || !__DISABLE_MP_LEGACY_SUPPORT_SYSCONF_WRAP__)            && \
 						    __MP_LEGACY_SUPPORT_SYSCONF_WRAP__)
 
 /* pthread_rwlock_initializer is not defined on Tiger */

--- a/include/MacportsLegacyWrappers/wrapper_macros.h
+++ b/include/MacportsLegacyWrappers/wrapper_macros.h
@@ -24,7 +24,7 @@
 #define __DISABLE_MP_LEGACY_SUPPORT_FUNCTION_WRAPPING__ 1
 #endif
 
-#if !__DISABLE_MP_LEGACY_SUPPORT_FUNCTION_WRAPPING__
+#if !defined (__DISABLE_MP_LEGACY_SUPPORT_FUNCTION_WRAPPING__) || !__DISABLE_MP_LEGACY_SUPPORT_FUNCTION_WRAPPING__
 /* Could include Darwin's <sys/cdefs.h> and use __STRING, __CONCAT */
 /* But for wrappers we require __asm, thus GCC/Clang, thus ANSI C, anyway */
 


### PR DESCRIPTION
This just fixes noisy build warnings, no change in behavior intended.

I could have just defined the macros to 0 if undefined instead in `include/MacportsLegacySupport.h`, but that way is probably more generic.