### PR TITLE
support macos 10.12 getentropy

### DIFF
--- a/include/MacportsLegacySupport.h
+++ b/include/MacportsLegacySupport.h
@@ -43,6 +43,9 @@
 /* ** utimensat, futimens, UTIME_NOW, UTIME_OMIT */
 #define __MP_LEGACY_SUPPORT_UTIMENSAT__       (__APPLE__ && __ENVIRONMENT_MAC_OS_X_VERSION_MIN_REQUIRED__ < 101300)
 
+/* getentropy */
+#define __MP_LEGACY_SUPPORT_GETENTROPY__      (__APPLE__ && __ENVIRONMENT_MAC_OS_X_VERSION_MIN_REQUIRED__ < 101200)
+
 /* clock_gettime */
 #define __MP_LEGACY_SUPPORT_GETTIME__         (__APPLE__ && __ENVIRONMENT_MAC_OS_X_VERSION_MIN_REQUIRED__ < 101200)
 

--- a/src/arc4random.c
+++ b/src/arc4random.c
@@ -20,7 +20,7 @@
 
 // MP support header
 #include "MacportsLegacySupport.h"
-#if __MP_LEGACY_SUPPORT_ARC4RANDOM__
+#if __MP_LEGACY_SUPPORT_ARC4RANDOM__ || __MP_LEGACY_SUPPORT_GETENTROPY__
 
 /*
  * ChaCha based random number generator from OpenBSD.
@@ -66,7 +66,7 @@ typedef struct rand_state rand_state;
 
 
 /* kernel entropy */
-extern int _getentropy(void* buf, size_t n);
+extern int _getentropy(void* buf, size_t n) __DARWIN_ALIAS(getentropy);
 
 #define KEYSTREAM_ONLY
 
@@ -600,4 +600,4 @@ _getentropy(void* buf, size_t n)
 }
 
 
-#endif /* __MP_LEGACY_SUPPORT_ARC4RANDOM__ */
+#endif /* __MP_LEGACY_SUPPORT_ARC4RANDOM__ || __MP_LEGACY_SUPPORT_GETENTROPY__ */


### PR DESCRIPTION
@kencu This patch addresses the following error when using the `go1.17` amd64 binary release https://golang.org/dl/go1.17.darwin-amd64.tar.gz and the go 1.17 compiled binary `esbuild 0.12.22` installed from npm:
```
$ go version && esbuild --version
dyld: Symbol not found: _getentropy
```
Using this patch to build  `libMacportsLegacySupport.dylib` and setting `DYLD_INSERT_LIBRARIES` appropriately:
```
$ go version && esbuild --version
go version go1.17 darwin/amd64
0.12.22
```
Both `go1.17` and `esbuild 0.12.22` appear to produce correctly working code when tested on Mac OS X 10.9.5 / Darwin 13.4.0 x86_64.

I didn't put a lot of effort into this. Perhaps including all the symbols from `src/arc4random.c` is not ideal, although I didn't see any ill effects. Feel free to close this PR and push a better solution.