### PR TITLE
which: Point to MacPorts-provided tcsh

### DIFF
--- a/tiger_only/bin/which
+++ b/tiger_only/bin/which
@@ -1,4 +1,4 @@
-#!/bin/csh
+#!/opt/local/bin/tcsh
 #
 # DO NOT USE "csh -f"
 #


### PR DESCRIPTION
I occasionally get an error running "which" on Tiger because the system-provided `csh` doesn't like my `$LS_COLORS`:

```
$ which which
csh: Unknown colorls variable `rs'.
```

Modern tcsh provided by MP does not appear to have this issue – so I propose switching to that.

If this PR is approved, the `legacy-support` Portfile will need a run-time `tcsh` dependency added on Tiger.