### PR TITLE
Define `u_char` etc on Tiger using Leopard rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,11 @@ Wrapped headers and replaced functions are:
     <td>OSX10.4</td>
   </tr>
   <tr>
+    <td><code>sys/types.h</code></td>
+    <td>Adds definitions for <code>u_char</code>, <code>u_short</code>, <code>u_int</code>, <code>u_long</code>, <code>ushort</code>, and <code>uint</code> types that can be exposed via <code>_DARWIN_C_SOURCE</code></td>
+    <td>OSX10.4</td>
+  </tr>
+  <tr>
     <td rowspan="3"><code>sys/unistd.h</code></td>
     <td>Adds <code>getattrlistat</code>, <code>readlinkat</code>, <code>faccessat</code>,
         <code>fchownat</code>, <code>linkat</code>, <code>symlinkat</code>,

--- a/tiger_only/include/sys/types.h
+++ b/tiger_only/include/sys/types.h
@@ -1,0 +1,86 @@
+/* Use _DARWIN_C_SOURCE as an override to provide u_char etc, a la Leopard */
+
+/* Original copyright notice preserved below */
+
+/*
+ * Copyright (c) 2000-2004 Apple Computer, Inc. All rights reserved.
+ *
+ * @APPLE_LICENSE_HEADER_START@
+ * 
+ * The contents of this file constitute Original Code as defined in and
+ * are subject to the Apple Public Source License Version 1.1 (the
+ * "License").  You may not use this file except in compliance with the
+ * License.  Please obtain a copy of the License at
+ * http://www.apple.com/publicsource and read it before using this file.
+ * 
+ * This Original Code and all software distributed under the License are
+ * distributed on an "AS IS" basis, WITHOUT WARRANTY OF ANY KIND, EITHER
+ * EXPRESS OR IMPLIED, AND APPLE HEREBY DISCLAIMS ALL SUCH WARRANTIES,
+ * INCLUDING WITHOUT LIMITATION, ANY WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE OR NON-INFRINGEMENT.  Please see the
+ * License for the specific language governing rights and limitations
+ * under the License.
+ * 
+ * @APPLE_LICENSE_HEADER_END@
+ */
+/* Copyright (c) 1995 NeXT Computer, Inc. All Rights Reserved */
+/*-
+ * Copyright (c) 1982, 1986, 1991, 1993, 1994
+ *	The Regents of the University of California.  All rights reserved.
+ * (c) UNIX System Laboratories, Inc.
+ * All or some portions of this file are derived from material licensed
+ * to the University of California by American Telephone and Telegraph
+ * Co. or Unix System Laboratories, Inc. and are reproduced herein with
+ * the permission of UNIX System Laboratories, Inc.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. All advertising materials mentioning features or use of this software
+ *    must display the following acknowledgement:
+ *	This product includes software developed by the University of
+ *	California, Berkeley and its contributors.
+ * 4. Neither the name of the University nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE REGENTS AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE REGENTS OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ *
+ *	@(#)types.h	8.4 (Berkeley) 1/21/94
+ */
+
+#include_next <sys/types.h>
+
+#ifndef _MACPORTS_SYS_TYPES_H_
+#define _MACPORTS_SYS_TYPES_H_
+
+/* If _POSIX_C_SOURCE was NOT defined, these typedefs were already included */
+
+#if defined(_POSIX_C_SOURCE) && defined(_DARWIN_C_SOURCE)
+typedef unsigned char       u_char;
+typedef unsigned short      u_short;
+typedef unsigned int        u_int;
+#ifndef _U_LONG
+typedef unsigned long       u_long;
+#define _U_LONG
+#endif
+typedef unsigned short      ushort;     /* Sys V compatibility */
+typedef unsigned int        uint;       /* Sys V compatibility */
+#endif
+
+#endif /* _MACPORTS_SYS_TYPES_H_ */


### PR DESCRIPTION
A number of ports run into trouble compiling on Tiger because `_XOPEN_SOURCE` results in `_POSIX_C_SOURCE` being defined, thus hiding the `u_char`, `u_int`, and other typedefs.

Leopard and later provide a workaround in the form of `_DARWIN_C_SOURCE`; follow this behavior.

See: https://trac.macports.org/ticket/52070
See: https://trac.macports.org/ticket/62997

(Note that this PR will do nothing in practical terms until the `legacysupport` Portfile is modified.)