### PR TITLE
fcntl.h: Expose flock(2) and friends on Tiger

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,10 @@ Wrapped headers and replaced functions are:
     <td rowspan="2"><code>sys/fcntl.h</code></td>
     <td>Adds missing <code>O_CLOEXEC</code>, <code>AT_FDCWD</code>, <code>AT_EACCESS</code>,
         <code>AT_SYMLINK_NOFOLLOW</code>, <code>AT_SYMLINK_FOLLOW</code>, and
-        <code>AT_REMOVEDIR</code> definitions</td>
+        <code>AT_REMOVEDIR</code> definitions.
+        On 10.4, expose <code>flock(2)</code>, <code>LOCK_SH</code>, <code>LOCK_EX</code>,
+        <code>LOCK_NB</code>, and <code>LOCK_UN</code> whenever <code>_DARWIN_C_SOURCE</code>
+        is defined (matches 10.5 SDK).</td>
     <td>as required (?)</td>
   </tr>
   <tr>

--- a/include/MacportsLegacySupport.h
+++ b/include/MacportsLegacySupport.h
@@ -112,6 +112,9 @@
 /* localtime_r, gmtime_r, etc only declared on Tiger when _ANSI_SOURCE and _POSIX_C_SOURCE are undefined */
 #define __MP_LEGACY_SUPPORT_TIME_THREAD_SAFE_FUNCTIONS__     (__APPLE__ && __ENVIRONMENT_MAC_OS_X_VERSION_MIN_REQUIRED__ < 1050)
 
+/* flock(2) requires _POSIX_C_SOURCE to be undefined on Tiger. Allow overriding with _DARWIN_C_SOURCE, same as Leopard. */
+#define __MP_LEGACY_SUPPORT_FLOCK__           (__APPLE__ && __ENVIRONMENT_MAC_OS_X_VERSION_MIN_REQUIRED__ < 1050)
+
 /* lsmod does not exist on Tiger */
 #define __MP_LEGACY_SUPPORT_LSMOD__           (__APPLE__ && __ENVIRONMENT_MAC_OS_X_VERSION_MIN_REQUIRED__ < 1050)
 

--- a/include/sys/fcntl.h
+++ b/include/sys/fcntl.h
@@ -61,4 +61,22 @@ __MP__END_DECLS
 
 #endif /* __MP_LEGACY_SUPPORT_ATCALLS__ */
 
+/* flock(2) */
+#if __MP_LEGACY_SUPPORT_FLOCK__
+
+/* Mimic Leopard behavior; flock already defined in main fcntl.h if _POSIX_C_SOURCE was undef */
+#if defined(_POSIX_C_SOURCE) && defined(_DARWIN_C_SOURCE)
+/* lock operations for flock(2) */
+#define LOCK_SH     0x01        /* shared file lock */
+#define LOCK_EX     0x02        /* exclusive file lock */
+#define LOCK_NB     0x04        /* don't block when locking */
+#define LOCK_UN     0x08        /* unlock file */
+
+__MP__BEGIN_DECLS
+int flock(int, int);
+__MP__END_DECLS
+#endif /* _POSIX_C_SOURCE && _DARWIN_C_SOURCE */
+
+#endif /* __MP_LEGACY_SUPPORT_FLOCK__ */
+
 #endif /* _MACPORTS_SYSFCNTL_H_ */


### PR DESCRIPTION
Match the 10.5 SDK with use of `_DARWIN_C_SOURCE`.

There will be a few more PRs like this in the coming days as I try to get `tmux` building on 10.4. This is a difficult issue to patch in application code; the usual workaround requires something like

```
#ifdef _POSIX_C_SOURCE
#define OLD_POSIX_C_SOURCE _POSIX_C_SOURCE
#undef _POSIX_C_SOURCE
#include <fcntl.h>
#define _POSIX_C_SOURCE OLD_POSIX_C_SOURCE
#else
#include <fcntl.h>
#endif
```

For a similar (but not directly impacted) issue see https://trac.macports.org/ticket/53421