### PR TITLE
clock_gettime: Cache timebase

### DIFF
--- a/src/time.c
+++ b/src/time.c
@@ -31,7 +31,7 @@ int clock_gettime( clockid_t clk_id, struct timespec *ts )
   int ret = -1;
   if ( ts )
   {
-    if      ( CLOCK_REALTIME == clk_id )
+    if ( CLOCK_REALTIME == clk_id )
     {
       struct timeval tv;
       ret = gettimeofday(&tv, NULL);
@@ -40,10 +40,12 @@ int clock_gettime( clockid_t clk_id, struct timespec *ts )
     }
     else if ( CLOCK_MONOTONIC == clk_id || CLOCK_MONOTONIC_RAW == clk_id )
     {
-      const uint64_t clock = mach_absolute_time();
-      mach_timebase_info_data_t timebase;
-      mach_timebase_info(&timebase);
-      uint64_t tdiff = clock * timebase.numer / timebase.denom;
+      const uint64_t t = mach_absolute_time();
+      static mach_timebase_info_data_t timebase;
+      if (timebase.numer == 0 || timebase.denom == 0) {
+        mach_timebase_info(&timebase);
+      }
+      const uint64_t tdiff = t * timebase.numer / timebase.denom;
       if ( CLOCK_MONOTONIC == clk_id ) {
         tdiff = THOUSAND * ( tdiff / THOUSAND );
       }


### PR DESCRIPTION
On versions of osx before 10.12, mach_timebase_info is a direct syscall (see dyld-239.3/glue.c#L434) which is order of magnitudes slower than the subsequent mach_absolute_time() call. Hence it's better to just cache it after the first call.

Since 10.12+, Apple also realized this and began caching mach_timebase_info calls at the libc layer (https://opensource.apple.com/source/xnu/xnu-3789.41.3/libsyscall/wrappers/mach_timebase_info.c.auto.html)