### PR TITLE
Fix fdopendir so dirfd stays open until closedir (for fstatat etc)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -54,7 +54,7 @@ FORCE_ARCH      ?=
 ARCHFLAGS       ?=
 LIPO            ?= lipo
 CC              ?= cc $(ARCHFLAGS)
-CFLAGS          ?= -Os -Wall
+CFLAGS          ?= -Os -Wall -Wno-deprecated-declarations
 DLIBCFLAGS      ?= -fPIC
 SLIBCFLAGS      ?=
 CXX             ?= c++ $(ARCHFLAGS)
@@ -84,7 +84,7 @@ FIND_LIBHEADERS := find $(SRCINCDIR) -type f \( -name '*.h' -o \
 LIBHEADERS      := $(shell $(FIND_LIBHEADERS))
 ALLHEADERS      := $(LIBHEADERS) $(wildcard $(SRCDIR)/*.h)
 
-MULTISRCS       := $(SRCDIR)/fdopendir.c
+MULTISRCS       := # Used to have $(SRCDIR)/fdopendir.c because it used struct stat
 ADDSRCS         := $(SRCDIR)/add_symbols.c
 LIBSRCS         := $(filter-out $(MULTISRCS) $(ADDSRCS),$(wildcard $(SRCDIR)/*.c))
 

--- a/README.md
+++ b/README.md
@@ -41,7 +41,10 @@ Wrapped headers and replaced functions are:
   </tr>
   <tr>
     <td><code>dirent.h</code></td>
-    <td>Adds <code>fdopendir</code> function</td>
+    <td>Adds <code>fdopendir</code> function, and wraps <code>opendir</code>,
+    <code>readdir</code>, <code>readdir_r</code>, <code>rewinddir</code>,
+    <code>seekdir</code>, <code>telldir</code>, <code>dirfd</code>, and
+    <code>closedir</code>, to support <code>fdopendir</code></td>
     <td>OSX10.9</td>
   </tr>
   <tr>

--- a/include/dirent.h
+++ b/include/dirent.h
@@ -1,6 +1,7 @@
 
 /*
  * Copyright (c) 2019
+ * Copyright (c) 2023 raf <raf@raf.org>, Tavian Barnes <tavianator@tavianator.com>
  *
  * Permission to use, copy, modify, and distribute this software for any
  * purpose with or without fee is hereby granted, provided that the above
@@ -27,6 +28,14 @@
 /* fdopendir */
 #if __MP_LEGACY_SUPPORT_FDOPENDIR__
 
+/* Wrapper struct for DIR */
+typedef struct __MP_LEGACY_SUPPORT_DIR __MP_LEGACY_SUPPORT_DIR;
+struct __MP_LEGACY_SUPPORT_DIR {
+    DIR *__mpls_dir;
+    int __mpls_dirfd;
+};
+#define DIR __MP_LEGACY_SUPPORT_DIR
+
 __MP__BEGIN_DECLS
 
 #ifndef __DARWIN_ALIAS_I
@@ -35,7 +44,47 @@ extern DIR *fdopendir(int fd) __DARWIN_ALIAS(fdopendir);
 extern DIR *fdopendir(int fd) __DARWIN_ALIAS_I(fdopendir);
 #endif
 
-__MP__END_DECLS
+/* Wrapper functions/macros to support fdopendir */
+extern DIR *__mpls_opendir(const char *name);
+extern int __mpls_closedir(DIR *dir);
+extern int __mpls_dirfd(DIR *dir);
+
+#define opendir(name)      __mpls_opendir(name)
+#define closedir(dir)      __mpls_closedir(dir)
+
+#ifndef __MP_LEGACY_SUPPORT_NO_DIRFD_MACRO
+#undef dirfd
+#define dirfd(dir)         __mpls_dirfd(dir)
 #endif
+
+static inline struct dirent *__mpls_readdir(DIR *dir) {
+    return readdir(dir->__mpls_dir);
+}
+
+static inline int __mpls_readdir_r(DIR *dir, struct dirent *entry, struct dirent **result) {
+    return readdir_r(dir->__mpls_dir, entry, result);
+}
+
+static inline void __mpls_rewinddir(DIR *dir) {
+    rewinddir(dir->__mpls_dir);
+}
+
+static inline void __mpls_seekdir(DIR *dir, long loc) {
+    seekdir(dir->__mpls_dir, loc);
+}
+
+static inline long __mpls_telldir(DIR *dir) {
+    return telldir(dir->__mpls_dir);
+}
+
+#define readdir __mpls_readdir
+#define readdir_r __mpls_readdir_r
+#define rewinddir __mpls_rewinddir
+#define seekdir __mpls_seekdir
+#define telldir __mpls_telldir
+
+__MP__END_DECLS
+
+#endif /* __MP_LEGACY_SUPPORT_FDOPENDIR__ */
 
 #endif /* _MACPORTS_DIRENT_H_ */

--- a/src/best_fchdir.c
+++ b/src/best_fchdir.c
@@ -1,5 +1,6 @@
 /*-
  * Copyright (c) 2019
+ * Copyright (c) 2023 raf <raf@raf.org>
  *
  *
  * THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
@@ -30,7 +31,10 @@ int best_fchdir(int dirfd)
   return syscall(SYS___pthread_fchdir, dirfd);
 #else
 /* Tiger does not have kernel support for __pthread_fchdir, so we have to fall back to fchdir */
-/* unless we can come up with a per-thread compatible implementation that works on Tiger */
+/* unless we can come up with a per-thread compatible implementation that works on Tiger. */
+/* Accept dirfd == -1 (which is meaningful for __pthread_fchdir) but do nothing with it. */
+  if (dirfd == -1)
+    return 0;
   return syscall(SYS_fchdir, dirfd);
 #endif
 }

--- a/test/test_fdopendir.c
+++ b/test/test_fdopendir.c
@@ -1,6 +1,7 @@
 
 /*
  * Copyright (c) 2019
+ * Copyright (c) 2023 raf <raf@raf.org>
  *
  * Permission to use, copy, modify, and distribute this software for any
  * purpose with or without fee is hereby granted, provided that the above
@@ -15,9 +16,11 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  */
 
+#include <stdlib.h>
 #include <dirent.h>
 #include <sys/stat.h>
 #include <sys/types.h>
+#include <sys/errno.h>
 #include <unistd.h>
 #include <limits.h>
 #include <fcntl.h>
@@ -55,6 +58,29 @@ int main() {
     }
 
     close(dfd);
+
+    /* Try to use fdopendir with stdin - Should fail with ENOTDIR */
+
+    if ((dir = fdopendir(STDIN_FILENO))) {
+        fprintf(stderr, "fdopendir(stdin) should have failed\n");
+        (void)closedir(dir);
+        return 1;
+    } else if (errno != ENOTDIR) {
+        perror("fdopendir(stdin) should have failed with ENOTDIR");
+        return 1;
+    }
+
+    /* Try to use fdopendir with -1 - Should fail with EBADF */
+
+    if ((dir = fdopendir(-1))) {
+        fprintf(stderr, "fdopendir(-1) should have failed\n");
+        (void)closedir(dir);
+        return 1;
+    } else if (errno != EBADF) {
+        perror("fdopendir(-1) should have failed with EBADF");
+        return 1;
+    }
+
     return 0;
 }
 

--- a/test/test_fmemopen.c
+++ b/test/test_fmemopen.c
@@ -108,10 +108,10 @@ test_autoalloc()
      * Let fmemopen allocate the buffer.
      */
 
-    char str[] = "A quick test";
+    /* char str[] = "A quick test"; */
     FILE *fp;
     long pos;
-    size_t nofw, nofr, i;
+    size_t nofw, i;
     int rc;
 
     /* Open a FILE * using fmemopen. */

--- a/test/test_traverse.c
+++ b/test/test_traverse.c
@@ -1,0 +1,184 @@
+
+/*
+ * Copyright (c) 2023 raf <raf@raf.org>
+ *
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ */
+
+/*
+Test directory traversal with macports legacysupport.
+
+This test creates ".test.dir", ".test.dir/subdir" and ".test.dir/subdir/file".
+It then traverses the ".test.dir" directory.
+It then deletes ".test.dir" and its contents.
+
+The output should look something like:
+
+  cwd (before traverse) /.../macports-legacy-support  
+  fstatat(parent_fd=-2, .test.dir) ok
+  openat(parent_fd=-2, .test.dir) = dir_fd=3 ok
+  fdopendir(dir_fd=3) ok
+  entry subdir
+  fstatat(parent_fd=3, subdir) ok
+  openat(parent_fd=3, subdir) = dir_fd=4 ok
+  fdopendir(dir_fd=4) ok
+  entry file
+  fstatat(parent_fd=4, file) ok
+  cwd (after traverse)  /.../macports-legacy-support
+
+This differs from test/test_traverse_cwd.c which
+chdirs to the named directory and then traverses "."
+rather than a named directory. Originally, these
+exhibited different errors.
+
+*/
+
+#include <stdlib.h>
+#include <stdio.h>
+#include <unistd.h>
+#include <string.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <dirent.h>
+#include <sys/stat.h>
+
+int traverse(int parent_fd, const char *name)
+{
+    /* Test: fstatat(AT_FDCWD, .test.dir) */
+
+    struct stat statbuf[1];
+
+    if (fstatat(parent_fd, name, statbuf, AT_SYMLINK_NOFOLLOW) == -1)
+    {
+        fprintf(stderr, "fstatat(parent_fd=%d, %s) failed: %s\n", parent_fd, name, strerror(errno));
+        return EXIT_FAILURE;
+    }
+
+    printf("fstatat(parent_fd=%d, %s) ok\n", parent_fd, name);
+
+    /* If it's a directory, process its entries */
+
+    if ((statbuf->st_mode & S_IFMT) == S_IFDIR)
+    {
+        /* Open it with openat() */
+
+        int dir_fd;
+
+        if ((dir_fd = openat(parent_fd, name, O_RDONLY)) == -1)
+        {
+            fprintf(stderr, "openat(parent_fd=%d, %s) failed: %s\n", parent_fd, name, strerror(errno));
+            return EXIT_FAILURE;
+        }
+
+        printf("openat(parent_fd=%d, %s) = dir_fd=%d ok\n", parent_fd, name, dir_fd);
+
+        /* Open it for traversing with fdopendir() */
+
+        DIR *dir;
+
+        if (!(dir = fdopendir(dir_fd)))
+        {
+            fprintf(stderr, "fdopendir(dir_fd=%d, .test.dir) failed\n", dir_fd);
+            close(dir_fd);
+            return EXIT_FAILURE;
+        }
+
+        printf("fdopendir(dir_fd=%d) ok\n", dir_fd);
+
+        /* Apply recursively to this directory's entries */
+
+        struct dirent *entry;
+
+        while ((entry = readdir(dir)))
+        {
+            if (!strcmp(entry->d_name, ".") || !strcmp(entry->d_name, ".."))
+                continue;
+
+            printf("entry %s\n", entry->d_name);
+
+            if (traverse(dir_fd, entry->d_name) == EXIT_FAILURE)
+                return EXIT_FAILURE;
+        }
+
+        closedir(dir);
+    }
+
+    return EXIT_SUCCESS;
+}
+
+int main(int argc, char **argv)
+{
+    /* Prepare: Create a directory */
+
+    system("rm -rf .test.dir");
+
+    if (mkdir(".test.dir", (mode_t)0755) == -1)
+    {
+        perror("mkdir(.test.dir) failed\n");
+        exit(EXIT_FAILURE);
+    }
+
+    /* And a directory within it */
+
+    if (mkdir(".test.dir/subdir", (mode_t)0755) == -1)
+    {
+        perror("mkdir(.test.dir/subdir) failed\n");
+        (void)rmdir(".test.dir");
+        exit(EXIT_FAILURE);
+    }
+
+    /* And a file within that */
+
+    int fd;
+
+    if ((fd = creat(".test.dir/subdir/file", (mode_t)0644)) == -1)
+    {
+        perror("creat(.test.dir/subdir/file) failed\n");
+        (void)rmdir(".test.dir/subdir");
+        (void)rmdir(".test.dir");
+        exit(EXIT_FAILURE);
+    }
+
+    close(fd);
+
+    /* Test directory traversal */
+
+    char cwdbuf1[BUFSIZ];
+    printf("cwd (before traverse) %s\n", getcwd(cwdbuf1, BUFSIZ));
+
+    int rc = traverse(AT_FDCWD, ".test.dir");
+
+    char cwdbuf2[BUFSIZ];
+    printf("cwd (after traverse)  %s\n", getcwd(cwdbuf2, BUFSIZ));
+
+    if (strcmp(cwdbuf1, cwdbuf2)) /* Originally, this happened on macos-10.4 */
+    {
+        fprintf(stderr, "Directory has changed while traversing!\n");
+        rc = EXIT_FAILURE;
+    }
+
+    /* Cleanup */
+
+    if (unlink(".test.dir/subdir/file") == -1)
+        perror("unlink .test.dir/subdir/file failed");
+
+    if (rmdir(".test.dir/subdir") == -1)
+        perror("rmdir .test.dir/subdir failed");
+
+    if (rmdir(".test.dir") == -1)
+        perror("rmdir .test.dir failed");
+
+    return rc;
+}
+

--- a/test/test_traverse_cwd.c
+++ b/test/test_traverse_cwd.c
@@ -1,0 +1,204 @@
+
+/*
+ * Copyright (c) 2023 raf <raf@raf.org>
+ *
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ */
+
+/*
+Test directory traversal with macports legacysupport.
+
+This test creates ".test.dir", ".test.dir/subdir" and ".test.dir/subdir/file".
+It then chdirs into ".test.dir" and then traverses ".".
+It then chdirs to ".." afterwards.
+It then deletes ".test.dir" and its contents.
+
+The output should look something like:
+
+  fstatat(parent_fd=-2, .) ok
+  openat(parent_fd=-2, .) = dir_fd=3 ok
+  fdopendir(dir_fd=3) ok
+  entry subdir
+  fstatat(parent_fd=3, subdir) ok
+  openat(parent_fd=3, subdir) = dir_fd=4 ok
+  fdopendir(dir_fd=4) ok
+  entry file
+  fstatat(parent_fd=4, file) ok
+  cwd (before cd ..) /Users/.../macports-legacy-support/.test.dir
+  cwd (after cd ..)  /Users/.../macports-legacy-support
+
+This differs from test/test_traverse.c which traverses a
+named directory rather than ".". Originally, these
+exhibited different errors.
+
+*/
+
+#include <stdlib.h>
+#include <stdio.h>
+#include <unistd.h>
+#include <string.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <dirent.h>
+#include <sys/stat.h>
+
+int traverse(int parent_fd, const char *name)
+{
+    /* Test: fstatat(AT_FDCWD, .test.dir) */
+
+    struct stat statbuf[1];
+
+    if (fstatat(parent_fd, name, statbuf, AT_SYMLINK_NOFOLLOW) == -1)
+    {
+        fprintf(stderr, "fstatat(parent_fd=%d, %s) failed: %s\n", parent_fd, name, strerror(errno));
+        return EXIT_FAILURE;
+    }
+
+    printf("fstatat(parent_fd=%d, %s) ok\n", parent_fd, name);
+
+    /* If it's a directory, process its entries */
+
+    if ((statbuf->st_mode & S_IFMT) == S_IFDIR)
+    {
+        /* Open it with openat() */
+
+        int dir_fd;
+
+        if ((dir_fd = openat(parent_fd, name, O_RDONLY)) == -1)
+        {
+            fprintf(stderr, "openat(parent_fd=%d, %s) failed: %s\n", parent_fd, name, strerror(errno));
+            return EXIT_FAILURE;
+        }
+
+        printf("openat(parent_fd=%d, %s) = dir_fd=%d ok\n", parent_fd, name, dir_fd);
+
+        /* Open it for traversing with fdopendir() */
+
+        DIR *dir;
+
+        if (!(dir = fdopendir(dir_fd)))
+        {
+            fprintf(stderr, "fdopendir(dir_fd=%d, dir) failed\n", dir_fd);
+            close(dir_fd);
+            return EXIT_FAILURE;
+        }
+
+        printf("fdopendir(dir_fd=%d) ok\n", dir_fd);
+
+        /* Apply recursively to this directory's entries */
+
+        struct dirent *entry;
+
+        while ((entry = readdir(dir)))
+        {
+            if (!strcmp(entry->d_name, ".") || !strcmp(entry->d_name, ".."))
+                continue;
+
+            printf("entry %s\n", entry->d_name);
+
+            if (traverse(dir_fd, entry->d_name) == EXIT_FAILURE)
+                return EXIT_FAILURE;
+        }
+
+        closedir(dir);
+    }
+
+    return EXIT_SUCCESS;
+}
+
+int main(int argc, char **argv)
+{
+    /* Prepare: Create a directory */
+
+    system("rm -rf .test.dir");
+
+    if (mkdir(".test.dir", (mode_t)0755) == -1)
+    {
+        perror("mkdir(.test.dir) failed\n");
+        exit(EXIT_FAILURE);
+    }
+
+    /* And a directory within it */
+
+    if (mkdir(".test.dir/subdir", (mode_t)0755) == -1)
+    {
+        perror("mkdir(.test.dir/subdir) failed\n");
+        (void)rmdir(".test.dir");
+        exit(EXIT_FAILURE);
+    }
+
+    /* And a file within that */
+
+    int fd;
+
+    if ((fd = creat(".test.dir/subdir/file", (mode_t)0644)) == -1)
+    {
+        perror("creat(.test.dir/subdir/file) failed\n");
+        (void)rmdir(".test.dir/subdir");
+        (void)rmdir(".test.dir");
+        exit(EXIT_FAILURE);
+    }
+
+    close(fd);
+
+    /* Test directory traversal */
+
+    fprintf(stderr, "cd .test.dir\n");
+    if (chdir(".test.dir") == -1)
+        perror("chdir(.test.dir) failed");
+
+    int rc = traverse(AT_FDCWD, ".");
+
+    char cwdbuf1[BUFSIZ];
+    char cwdbuf2[BUFSIZ];
+
+    printf("cwd (before cd ..) %s\n", getcwd(cwdbuf1, BUFSIZ));
+
+    if (chdir("..") == -1)
+        perror("chdir .. failed");
+
+    printf("cwd (after cd ..)  %s\n", getcwd(cwdbuf2, BUFSIZ));
+
+    if (!strcmp(cwdbuf1, cwdbuf2))
+    {
+        fprintf(stderr, "Post-traversal chdir(..) silently failed to change directory!\n");
+        fprintf(stderr, "Replacing best_fchdir() in fdopendir() with fchdir() fixes this badly.\n");
+        fprintf(stderr, "Using _ATCALL for opendir fixes this properly.\n");
+        rc = EXIT_FAILURE;
+    }
+
+    /* Cleanup */
+
+    if (unlink(".test.dir/subdir/file") == -1)
+        perror("unlink .test.dir/subdir/file failed");
+
+    if (rmdir(".test.dir/subdir") == -1)
+        perror("rmdir .test.dir/subdir failed");
+
+    if (rmdir(".test.dir") == -1)
+        perror("rmdir .test.dir failed");
+
+    /* If the above cleanup didn't work (because chdir .. silently failed to work) */
+
+    if (!strcmp(cwdbuf1, cwdbuf2))
+    {
+        fprintf(stderr, "Cleaning up\n");
+        (void)unlink("../.test.dir/subdir/file");
+        (void)rmdir("../.test.dir/subdir");
+        (void)rmdir("../.test.dir");
+    }
+
+    return rc;
+}
+


### PR DESCRIPTION
This pull request changes `fdopendir()` so that the supplied directory file descriptor remains open until `closedir()` is called. This makes it possible for functions like `fstatat()` and `unlinkat()` to use the directory file descriptor (without changing its state) while traversing a directory hierarchy.

This was prompted by a pull request to get the sysutils/rawhide port working with legacysupport:

https://github.com/macports/macports-ports/pull/19047

https://trac.macports.org/ticket/67754

It changes `include/dirent.h` to include a wrapper struct and macro for `DIR` that contains the real `DIR*` as well as an `int` to store the supplied directory file descriptor. All of the functions that take a `DIR*` as an argument need wrappers as well.

There are wrapper macros for `readdir()`, `readdir_r()`, `rewinddir()`, `seekdir()` and `telldir()`, and there are wrapper functions and macros for `opendir()`, `closedir()` and `dirfd()`.

It changes `src/fdopendir.c` to change the implementation of `fdopendir()`. More on that below.

There is an additional source file (`src/fdopendir_support.c`). This was needed because the support functions (for `opendir()`, `closedir()` and `dirfd()`) couldn't reside in `src/fdopendir.c` because it uses `stat` and the wrappers don't. Compilation failed because `src/fdopendir.c` is compiled multiple times for different architectures but only a single function there was expected, and any additional functions end up being defined multiple times with the same name. The wrapper function for `dirfd()` only needed to be a function because the real `dirfd()` is already a macro.

There are two additional test files (`test/test_traverse.c` and `test/test_traverse_cwd.c`). They test two similar directory hierarchy traversals. One traverses a named directory. The other traverses the current directory (`"."`). Originally, they exhibited different errors (`Bad file descriptor` or `No such file or directory`) in subdirectories.

The `fdopendir()` implementation was changed to create and return the wrapper struct which stores the supplied file descriptor, so that it could remain open. Other functions would take the wrapper struct as an argument. When the `closedir()` wrapper is called, it closes the stored file descriptor.

That change was enough to fix uses of `fstatat()`, but a problem remained. The `test/test_traverse_cwd.c` test would `chdir()` into the test directory that it had created, then traverse `"."`, and then it would `chdir("..")` to get back to the starting directory to clean up the test directory that it had created, but the `chdir("..")` silently failed to work. It returned `0` but the current working directory was unchanged. It seemed impossible.

This was fixed in a way that might not be ideal. Replacing the two uses of `best_fchdir()` with `fchdir()` in `fdopendir()` fixed the problem, and the subsequent `chdir("..")` started working correctly.

According to `best_fchdir()`, it uses `__pthread_fchdir()` on macos-10.5 and later and it uses the real `fchdir()` on macos-10.4. I have no idea if `__pthread_fchdir()` really is the best `fchdir()`. I'm testing with macos-10.6. Perhaps the `__pthread_fchdir()` doesn't work properly on macos-10.6. Maybe it's something else.

Let me know if there is a better way to solve the `chdir()` problem. If `__pthread_fchdir` doesn't work on macos-10.6 but it does work on other systems, I could restore the calls to `best_fchdir()` if someone wants to run the tests on different systems to see if `test/test_traverse_cwd.c` works on any systems below macos-10.10. If some do, perhaps the implementation of `best_fchdir()` could be changed to only use `__pthread_fchdir()` on those systems, and use `fchdir()` on other systems. But `best_fchdir()` is used with atcalls and presumably works fine there. So maybe it doesn't need to change, and maybe it's OK to just not use it in `fdopendir()`.

P.S. There was a `FIXME` relating to tests failing on macos-10.4 when the supplied file descriptor is closed in `fdopendir()`, so it allowed the file descriptor leak to occur on macos-10.4. That can probably be considered fixed as well.