### PR TITLE
fstatat64: tests: add declaration for fstatat64 syscall, to fix build issues for newer macOS releases

### DIFF
--- a/test/test_fstatat64.c
+++ b/test/test_fstatat64.c
@@ -26,6 +26,14 @@
 
 #define FEEDBACK 1
 
+/*
+ * For newer macOS releases - where this syscall is available - it's declared
+ * in header 'sys/sysproto.h', within 'Kernel.framework'.
+ *
+ * To avoid depending on that, declare it ourselves. (Remember that C/C++
+ * allows redundant function declarations, as long as the signatures match.)
+ */
+int fstatat64(int dirfd, const char *pathname, struct stat64 *buf, int flags);
 
 int main (int argc, char **argv) {
 #if !__DARWIN_ONLY_64_BIT_INO_T && __ENVIRONMENT_MAC_OS_X_VERSION_MIN_REQUIRED__ >= 1050


### PR DESCRIPTION
On newer macOS releases - like, say, 10.15 - the test for `fstatat64` fails to build:

```
test/test_fstatat64.c:93:12:
error: implicit declaration of function 'fstatat64' is invalid in C99

if (0 != fstatat64 (AT_FDCWD, argv[0], &atfdcwd_stat64, 0)) {
         ^
```

Since this syscall is provided via header `sys/sysproto.h` - within `Kernel.framework` - it's not ideal to depend on the latter. So rather than going down that path, simply add a local declaration for `fstatat64`.

Fixes: [Ticket 65913 - legacy-support: tests: failure due to fstatat64](https://trac.macports.org/ticket/65913)