### PR TITLE
Ignore unimplemented AT_EACCESS flag, trac bugs #65569 and #67406

### DIFF
--- a/src/atcalls.c
+++ b/src/atcalls.c
@@ -104,6 +104,10 @@ int faccessat(int dirfd, const char *pathname, int mode, int flags)
     } __attribute__((aligned(4), packed)) ab;
     unsigned long opts = 0;
 
+    // Ignore AT_EACCESS, Bug #65569 and #67406
+    if (flags == AT_EACCESS)
+        flags = 0; // Zero out flag, ignore request to use effective user ID
+
     ERR_ON(EINVAL, flags & ~AT_SYMLINK_NOFOLLOW);
     if (flags & AT_SYMLINK_NOFOLLOW)
         opts |= FSOPT_NOFOLLOW;


### PR DESCRIPTION
Emacs currently doesn't compile on older versions of OS X because legacy-support doesn't implement the `AT_EACCESS` flag in `faccessat()` and instead returns an invalid argument error, which causes Emacs to crash during the phase where it tries to dump to disk. This patch instead zeros out the flag if it detects that it's `AT_EACCESS`, and will then attempt to access the file with the real user's permissions instead of the effective user. This allows Emacs to compile (since the macports user has access to its own build directory), and in my testing, I have yet to encounter any runtime issues. This should also fix any other program that has permission to access a file or directory with its real user's permissions, but fails just because it attempts to use `AT_EACCESS()` to get the effective user's permissions.
