### PR TITLE
Fix faccessat (setuid, setgid, AT_EACCESS, F_OK)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -295,6 +295,16 @@ test_cmath: test/test_cmath.cc $(ALLHEADERS)
 	$(info 4: $(CXX) -I$(SRCINCDIR) $(CXXFLAGS) -std=c++11 $< -o test/$@_cxx11)
 	@-$(CXX) -I$(SRCINCDIR) $(CXXFLAGS) -std=c++11 $< -o test/$@_cxx11 &> /dev/null && echo "4: c++11 legacy cmath build success (test succeeded)!" || echo "4: c++11 legacy cmath build failure (test failed)!"
 
+# Special clause for testing faccessat in a setuid program.
+# Must be run by root.
+# Assumes there is a _uucp user.
+# Tests setuid _uucp, setuid root, and setgid tty.
+test_faccessat_setuid: test/test_faccessat
+	@test/do_test_faccessat_setuid "$(BUILDDLIBPATH)"
+
+test_faccessat_setuid_msg:
+	@echo 'Run "sudo make test_faccessat_setuid" to test faccessat properly'
+
 $(TESTRUNS): $(TESTRUNPREFIX)%: $(TESTNAMEPREFIX)%
 	$<
 
@@ -325,11 +335,11 @@ install-slib: $(BUILDSLIBPATH)
 	$(MKINSTALLDIRS) $(DESTDIR)$(LIBDIR)
 	$(INSTALL_DATA) $(BUILDSLIBPATH) $(DESTDIR)$(LIBDIR)
 
-test check: $(TESTRUNS) test_cmath
+test check: $(TESTRUNS) test_cmath test_faccessat_setuid_msg
 
 clean:
 	$(RM) $(foreach D,$(SRCDIR) $(TESTDIR),$D/*.o $D/*.o.* $D/*.d)
-	$(RM) $(BUILDDLIBPATH) $(BUILDSLIBPATH) $(BUILDSYSLIBPATH) $(TESTPRGS) test/test_cmath_*
+	$(RM) $(BUILDDLIBPATH) $(BUILDSLIBPATH) $(BUILDSYSLIBPATH) $(TESTPRGS) test/test_cmath_* test/test_faccessat_setuid
 	@$(RMDIR) $(BUILDDLIBDIR) $(BUILDSLIBDIR)
 
 .PHONY: all dlib slib clean check test $(TESTRUNS) test_cmath

--- a/test/do_test_faccessat_setuid
+++ b/test/do_test_faccessat_setuid
@@ -1,0 +1,184 @@
+#!/bin/sh
+
+# Copyright (C) 2023 raf <raf@raf.org>
+#
+# Permission to use, copy, modify, and distribute this software for any
+# purpose with or without fee is hereby granted, provided that the above
+# copyright notice and this permission notice appear in all copies.
+#
+# THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+# WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+# MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+# ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+# WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+# ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+# OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+# When run as root, test faccessat() properly
+
+if [ "$(whoami)" != root ]
+then
+	echo 'Run "sudo make test_faccessat_setuid" to test faccessat properly'
+	exit 1
+fi
+
+# Define some names and functions
+
+lib="$1"
+s=test/test_faccessat_setuid
+t=test/tmp
+fail=0
+
+die() { echo "$0: $@" >&2; rm -rf $s $t; exit 1; }
+
+setid() # usage: setid owner group mode fname [createcmd]
+{
+	if [ -n "$5" ]; then $5 $4 || die "$5 $4 failed"; fi
+	chown $1 $4 || die "chown $1 $4 failed"
+	chgrp $2 $4 || die "chgrp $2 $4 failed"
+	chmod $3 $4 || die "chmod $3 $4 failed"
+}
+
+setup() # usage: setup owner group mode
+{
+	cp test/test_faccessat $s || die "cp $s failed"
+	# The following replaces the @executable_path-based library reference
+	# with an absolute path reference to the library-being-tested.
+	# This is needed for a setuid/setgid program to be allowed to load a library.
+	install_name_tool -change "@executable_path/../$lib" "$(pwd)/$lib" $s || die "install_name_tool $s failed"
+	setid $1 $2 $3 $s
+	setid $1 $2 $3 $t mkdir
+}
+
+check()
+{
+	"$@" || fail=1
+}
+
+clean()
+{
+	rm -rf $s $t
+}
+
+get_group()
+{
+	echo $(id $1 | sed -E 's/^.*gid=-?[0-9]+\(//; s/\).*$//')
+}
+
+get_supp_group()
+{
+	echo $(id $1 | sed -E 's/^.*groups=-?[0-9]+\([^)]+\),-?[0-9]+\(//; s/\).*$//')
+}
+
+uucp_group=$(get_group _uucp)
+nobody_group=$(get_group nobody)
+nobody_supp_group=$(get_supp_group nobody)
+
+# Run normal test as setuid _uucp (to test AT_EACCESS)
+
+echo setuid _uucp
+setup _uucp $uucp_group 4755
+check sudo -u nobody $s
+clean
+
+# Run normal test as setuid root (to test AT_EACCESS)
+
+echo setuid root
+setup root wheel 4755
+check sudo -u nobody $s
+clean
+
+# Test different numbers of leading dirs and leading dirs with different
+# permissions (to test leading executable check)
+
+setup _uucp $uucp_group 4755
+setid _uucp $uucp_group 644 $t/f touch
+setid _uucp $uucp_group 755 $t/d1 mkdir
+setid _uucp $uucp_group 000 $t/d2 mkdir
+setid _uucp $uucp_group 644 $t/d1/f touch
+setid _uucp $uucp_group 644 $t/d2/f touch
+
+echo leading dirs ruid=nobody euid=_uucp
+check sudo -u nobody $s test test/ \
+	$t $t/ $t/f \
+	$t/d1 $t/d1/ $t/d1/f \
+	$t/d2 $t/d2/ $t/d2/f
+
+echo leading dirs ruid=root euid=_uucp
+check $s test test/ \
+	$t $t/ $t/f \
+	$t/d1 $t/d1/ $t/d1/f \
+	$t/d2 $t/d2/ $t/d2/f
+
+chmod 755 $s
+
+echo leading dirs nobody
+check sudo -u nobody $s test test/ \
+	$t $t/ $t/f \
+	$t/d1 $t/d1/ $t/d1/f \
+	$t/d2 $t/d2/ $t/d2/f
+
+echo leading dirs root
+check $s test test/ \
+	$t $t/ $t/f \
+	$t/d1 $t/d1/ $t/d1/f \
+	$t/d2 $t/d2/ $t/d2/f
+
+clean
+
+# Test lots of permissions without setuid/setgid with the same user's files
+# (to test when uid matches)
+
+modes="444 400 040 004 222 200 020 002 111 100 010 001 000 755 644 777 4755 2755 1777"
+
+checkperms() # usage: checkperms fuser fgroup mode
+{
+	setup nobody $nobody_group $3
+	cases=
+	for m in $modes
+	do
+		setid $1 $2 $m $t/$m touch
+		setid $1 $2 $m $t/$m.d mkdir
+		cases="$cases $t/$m $t/$m.d"
+	done
+	sudo -u nobody $s $cases
+	clean
+}
+
+echo perm same user
+checkperms nobody $nobody_group 755
+
+# Test lots of permissions without setuid/setgid with different user's files
+# (to test when uid/gid don't match)
+
+echo perm diff user
+checkperms _uucp $uucp_group 755
+
+# Test lots of permissions without setuid/setgid with different user's files
+# but the same group (to test when uid doesn't match but gid does match)
+
+echo perm same group
+checkperms _uucp $nobody_group 755
+
+# Test lots of permissions without setuid/setgid with different user's files
+# but same supplementary group (to test when uid/gid don't match but a
+# supplementary group matches)
+
+echo perm same supp group
+checkperms _uucp $nobody_supp_group 755
+
+# Test lots of permissions with setuid with different user's files
+# (to test setuid)
+
+echo perm setuid _uucp
+checkperms _uucp $uucp_group 4755
+
+# Test lots of permissions with setgid with different user's files
+# (to test setgid)
+
+echo perm setgid _uucp
+checkperms _uucp $uucp_group 2755
+
+exit $fail
+
+# vi:set ts=4 sw=4:

--- a/test/test_faccessat.c
+++ b/test/test_faccessat.c
@@ -1,0 +1,382 @@
+/*
+ * Copyright (C) 2023 raf <raf@raf.org>
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
+#include <stdlib.h>
+#include <stdio.h>
+#include <unistd.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <pwd.h>
+#include <grp.h>
+
+int main(int ac, char **av)
+{
+	int failures = 0;
+	uid_t real_uid = getuid();
+	uid_t effective_uid = geteuid();
+	uid_t real_gid = getgid();
+	uid_t effective_gid = getegid();
+
+	// When supplied with arguments, compare faccessat() against access().
+	// We can't test AT_EACCESS here because access() can't do that.
+	// But some tests will be setuid, some setgid, and some neither.
+	// See test/do_test_faccessat_setuid for details.
+
+	if (ac > 1)
+	{
+		// For each file, test all modes in isolation and in all combinations
+
+		int modes[8] = { F_OK, R_OK, W_OK, X_OK, R_OK|W_OK, W_OK|X_OK, X_OK|R_OK, R_OK|W_OK|X_OK };
+		int a, m;
+
+		for (a = 1; a < ac; ++a)
+		{
+			for (m = 0; m < 8; ++m)
+			{
+				int faccessat_rc = faccessat(AT_FDCWD, av[a], modes[m], 0);
+				int faccessat_errno = errno;
+				int access_rc = access(av[a], modes[m]);
+				int access_errno = errno;
+
+				if (faccessat_rc != access_rc || (faccessat_rc < 0 && faccessat_errno != access_errno))
+				{
+					if (!failures)
+						fprintf(stderr, "faccessat_setuid: uid=%s euid=%s gid=%s egid=%s\n",
+							getpwuid(real_uid) ? getpwuid(real_uid)->pw_name : "?",
+							getpwuid(effective_uid) ? getpwuid(effective_uid)->pw_name : "?",
+							getgrgid(real_gid) ? getgrgid(real_gid)->gr_name : "?",
+							getgrgid(effective_gid) ? getgrgid(effective_gid)->gr_name : "?"
+						);
+
+					++failures;
+
+					fprintf(stderr, "faccessat(%s, %s%s%s%s) fail: %d %s != %d %s\n",
+						av[a],
+						(modes[m] == F_OK) ? "F" : "",
+						(modes[m] & R_OK) ? "R" : "",
+						(modes[m] & W_OK) ? "W" : "",
+						(modes[m] & X_OK) ? "X" : "",
+						faccessat_rc,
+						(faccessat_rc == -1) ? strerror(faccessat_errno) : "",
+						access_rc,
+						(access_rc == -1) ? strerror(access_errno) : ""
+					);
+
+					char buf[1024];
+					snprintf(buf, 1024, "/bin/ls -l %s", av[a]);
+					system(buf);
+				}
+			}
+		}
+
+		unlink(av[0]);
+
+		return (failures) ? 1 : 0;
+	}
+
+	// Without arguments, just create readable/writable/executable/inaccessible
+	// files and test faccessat() with and without AT_EACCESS. This is part of
+	// the automatic tests, but as part of manual testing might be setuid.
+	// Instead of comparing against access(), these tests have explicit expected
+	// results.
+
+	#define TMP "test/tmp"
+	const char *readable_path = TMP "/readable";
+	const char *writable_path = TMP "/writable";
+	const char *executable_path = TMP "/executable";
+	const char *inaccessible_path = TMP "/inaccessible";
+	const char *nonexistent_path = TMP "/nonexistent";
+
+	/* Create test/tmp directory if not already there (see make test_faccessat_setuid) */
+
+	int mkdir_rc = mkdir(TMP, 0700);
+	int mkdir_errno = errno;
+
+	if (mkdir_rc == -1 && mkdir_errno != EEXIST)
+	{
+		fprintf(stderr, "failed to create tmp directory %s: %s\n", TMP, strerror(errno));
+		return 1;
+	}
+
+	/* Create readable/writable/executable/inaccessible files (owned by effective user) */
+
+	int readable_fd = creat(readable_path, 0400);
+	if (readable_fd == -1)
+	{
+		fprintf(stderr, "failed to create readable file %s: %s\n", readable_path, strerror(errno));
+		if (mkdir_rc == 0)
+			rmdir(TMP);
+		return 1;
+	}
+
+	close(readable_fd);
+
+	int writable_fd = creat(writable_path, 0200);
+	if (writable_fd == -1)
+	{
+		fprintf(stderr, "failed to create writable file %s: %s\n", writable_path, strerror(errno));
+		unlink(readable_path);
+		if (mkdir_rc == 0)
+			rmdir(TMP);
+		return 1;
+	}
+
+	close(writable_fd);
+
+	int executable_fd = creat(executable_path, 0100);
+	if (executable_fd == -1)
+	{
+		fprintf(stderr, "failed to create executable file %s: %s\n", executable_path, strerror(errno));
+		unlink(readable_path);
+		unlink(writable_path);
+		if (mkdir_rc == 0)
+			rmdir(TMP);
+		return 1;
+	}
+
+	close(executable_fd);
+
+	int inaccessible_fd = creat(inaccessible_path, 0000);
+	if (inaccessible_fd == -1)
+	{
+		fprintf(stderr, "failed to create inaccessible file %s: %s\n", inaccessible_path, strerror(errno));
+		unlink(readable_path);
+		unlink(writable_path);
+		unlink(executable_path);
+		if (mkdir_rc == 0)
+			rmdir(TMP);
+		return 1;
+	}
+
+	close(inaccessible_fd);
+
+	/* Test faccessat() with no flags and with AT_EACCESS */
+
+	int dfd = open(".", O_RDONLY); errno = 0;
+	int readable_rok = faccessat(dfd, readable_path, R_OK, 0);
+	int readable_rok_errno = errno; errno = 0;
+	int writable_wok = faccessat(dfd, writable_path, W_OK, 0);
+	int writable_wok_errno = errno; errno = 0;
+	int executable_xok = faccessat(dfd, executable_path, X_OK, 0);
+	int executable_xok_errno = errno; errno = 0;
+	int inaccessible_rok = faccessat(dfd, inaccessible_path, R_OK, 0);
+	int inaccessible_rok_errno = errno; errno = 0;
+	int inaccessible_wok = faccessat(dfd, inaccessible_path, W_OK, 0);
+	int inaccessible_wok_errno = errno; errno = 0;
+	int inaccessible_xok = faccessat(dfd, inaccessible_path, X_OK, 0);
+	int inaccessible_xok_errno = errno; errno = 0;
+	int readable_erok = faccessat(dfd, readable_path, R_OK, AT_EACCESS);
+	int readable_erok_errno = errno; errno = 0;
+	int writable_ewok = faccessat(dfd, writable_path, W_OK, AT_EACCESS);
+	int writable_ewok_errno = errno; errno = 0;
+	int executable_exok = faccessat(dfd, executable_path, X_OK, AT_EACCESS);
+	int executable_exok_errno = errno; errno = 0;
+	int inaccessible_erok = faccessat(dfd, inaccessible_path, R_OK, AT_EACCESS);
+	int inaccessible_erok_errno = errno; errno = 0;
+	int inaccessible_ewok = faccessat(dfd, inaccessible_path, W_OK, AT_EACCESS);
+	int inaccessible_ewok_errno = errno; errno = 0;
+	int inaccessible_exok = faccessat(dfd, inaccessible_path, X_OK, AT_EACCESS);
+	int inaccessible_exok_errno = errno; errno = 0;
+
+	int readable_fok = faccessat(dfd, readable_path, F_OK, 0);
+	int readable_fok_errno = errno; errno = 0;
+	int writable_fok = faccessat(dfd, writable_path, F_OK, 0);
+	int writable_fok_errno = errno; errno = 0;
+	int executable_fok = faccessat(dfd, executable_path, F_OK, 0);
+	int executable_fok_errno = errno; errno = 0;
+	int inaccessible_fok = faccessat(dfd, inaccessible_path, F_OK, 0);
+	int inaccessible_fok_errno = errno; errno = 0;
+	int readable_efok = faccessat(dfd, readable_path, F_OK, AT_EACCESS);
+	int readable_efok_errno = errno; errno = 0;
+	int writable_efok = faccessat(dfd, writable_path, F_OK, AT_EACCESS);
+	int writable_efok_errno = errno; errno = 0;
+	int executable_efok = faccessat(dfd, executable_path, F_OK, AT_EACCESS);
+	int executable_efok_errno = errno; errno = 0;
+	int inaccessible_efok = faccessat(dfd, inaccessible_path, F_OK, AT_EACCESS);
+	int inaccessible_efok_errno = errno; errno = 0;
+
+	int nonexistent_fok = faccessat(dfd, nonexistent_path, F_OK, 0);
+	int nonexistent_fok_errno = errno; errno = 0;
+	int nonexistent_efok = faccessat(dfd, nonexistent_path, F_OK, AT_EACCESS);
+	int nonexistent_efok_errno = errno; errno = 0;
+	close (dfd);
+
+	#define TEST(cond, message, e) if (!(cond)) { errno = 0; fprintf(stderr, "%s %s\n", message, (e) ? strerror(e) : ""); ++failures; }
+
+	/* Test F_OK */
+
+	TEST(readable_fok == 0, "root: faccessat(readable F_OK) does not exist = FAIL", readable_fok_errno)
+	TEST(writable_fok == 0, "root: faccessat(writable F_OK) does not exist = FAIL", writable_fok_errno)
+	TEST(executable_fok == 0, "root: faccessat(executable F_OK) does not exist = FAIL", executable_fok_errno)
+	TEST(inaccessible_fok == 0, "root: faccessat(inaccessible F_OK) does not exist = FAIL", inaccessible_fok_errno)
+	TEST(readable_efok == 0, "root: faccessat(readable F_OK AT_EACCESS) does not exist = FAIL", readable_efok_errno)
+	TEST(writable_efok == 0, "root: faccessat(writable F_OK AT_EACCESS) does not exist = FAIL", writable_efok_errno)
+	TEST(executable_efok == 0, "root: faccessat(executable F_OK AT_EACCESS) does not exist = FAIL", executable_efok_errno)
+	TEST(inaccessible_efok == 0, "root: faccessat(inaccessible F_OK AT_EACCESS) does not exist = FAIL", inaccessible_efok_errno)
+	TEST(nonexistent_fok == -1, "root: faccessat(nonexistent F_OK) does exist = FAIL", nonexistent_fok_errno)
+	TEST(nonexistent_efok == -1, "root: faccessat(nonexistent F_OK AT_EACCESS) does exist = FAIL", nonexistent_efok_errno)
+
+	/* Test non-setuid program */
+
+	if (real_uid == effective_uid)
+	{
+		/* Test as non-root user */
+
+		if (real_uid != 0)
+		{
+			TEST(readable_rok == 0, "not root: faccessat(readable R_OK) is unreadable = FAIL", readable_rok_errno)
+			TEST(writable_wok == 0, "not root: faccessat(writable W_OK) is unwritable = FAIL", writable_wok_errno)
+			TEST(executable_xok == 0, "not root: faccessat(executable X_OK) is unexecutable = FAIL", executable_xok_errno)
+			TEST(inaccessible_rok == -1, "not root: faccessat(inaccessible R_OK) is readable = FAIL", inaccessible_rok_errno)
+			TEST(inaccessible_wok == -1, "not root: faccessat(inaccessible W_OK) is writable = FAIL", inaccessible_wok_errno)
+			TEST(inaccessible_xok == -1, "not root: faccessat(inaccessible X_OK) is executable = FAIL", inaccessible_xok_errno)
+			/* This isn't meaningful because uid == euid */
+			TEST(readable_erok == 0, "not root: faccessat(readable R_OK AT_EACCESS) is unreadable = FAIL", readable_erok_errno)
+			TEST(writable_ewok == 0, "not root: faccessat(writable W_OK AT_EACCESS) is unwritable = FAIL", writable_ewok_errno)
+			TEST(executable_exok == 0, "not root: faccessat(executable X_OK AT_EACCESS) is unexecutable = FAIL", executable_exok_errno)
+			TEST(inaccessible_erok == -1, "not root: faccessat(inaccessible R_OK AT_EACCESS) is readable = FAIL", inaccessible_erok_errno)
+			TEST(inaccessible_ewok == -1, "not root: faccessat(inaccessible W_OK AT_EACCESS) is writable = FAIL", inaccessible_ewok_errno)
+			TEST(inaccessible_exok == -1, "not root: faccessat(inaccessible X_OK AT_EACCESS) is executable = FAIL", inaccessible_exok_errno)
+		}
+
+		/* Test as root user */
+
+		else
+		{
+			TEST(readable_rok == 0, "root: faccessat(readable R_OK) is unreadable = FAIL", readable_rok_errno)
+			TEST(writable_wok == 0, "root: faccessat(writable W_OK) is unwritable = FAIL", writable_wok_errno)
+			TEST(executable_xok == 0, "root: faccessat(executable X_OK) is unexecutable = FAIL", executable_xok_errno)
+			TEST(inaccessible_rok == 0, "root: faccessat(inaccessible R_OK) is unreadable = FAIL", inaccessible_rok_errno)
+			TEST(inaccessible_wok == 0, "root: faccessat(inaccessible W_OK) is unwritable = FAIL", inaccessible_wok_errno)
+			TEST(inaccessible_xok == -1, "root: faccessat(inaccessible X_OK) is executable = FAIL", inaccessible_xok_errno)
+			/* This isn't meaningful because uid == euid */
+			TEST(readable_erok == 0, "root: faccessat(readable R_OK AT_EACCESS) is unreadable = FAIL", readable_erok_errno)
+			TEST(writable_ewok == 0, "root: faccessat(writable W_OK AT_EACCESS) is unwritable = FAIL", writable_ewok_errno)
+			TEST(executable_exok == 0, "root: faccessat(executable X_OK AT_EACCESS) is unexecutable = FAIL", executable_exok_errno)
+			TEST(inaccessible_erok == 0, "root: faccessat(inaccessible R_OK AT_EACCESS) is unreadable = FAIL", inaccessible_erok_errno)
+			TEST(inaccessible_ewok == 0, "root: faccessat(inaccessible W_OK AT_EACCESS) is unwritable = FAIL", inaccessible_ewok_errno)
+			TEST(inaccessible_exok == -1, "root: faccessat(inaccessible X_OK AT_EACCESS) is executable = FAIL", inaccessible_exok_errno)
+		}
+	}
+
+	/* Test setuid root program */
+	/* Note: Must be setuid root, run as non-root, linked using absolute path */
+
+	else if (real_uid != 0 && effective_uid == 0)
+	{
+		TEST(readable_rok == -1, "setuid root: non-root user: faccessat(readable R_OK) is readable = FAIL", readable_rok_errno)
+		TEST(writable_wok == -1, "setuid root: non-root user: faccessat(writable W_OK) is writable = FAIL", writable_wok_errno)
+		TEST(executable_xok == -1, "setuid root: non-root user: faccessat(executable X_OK) is executable = FAIL", executable_xok_errno)
+		TEST(inaccessible_rok == -1, "setuid root: non-root user: faccessat(inaccessible R_OK) is readable = FAIL", inaccessible_rok_errno)
+		TEST(inaccessible_wok == -1, "setuid root: non-root user: faccessat(inaccessible W_OK) is writable = FAIL", inaccessible_wok_errno)
+		TEST(inaccessible_xok == -1, "setuid root: non-root user: faccessat(inaccessible X_OK) is executable = FAIL", inaccessible_xok_errno)
+		/* This is meaningful because uid != euid */
+		TEST(readable_erok == 0, "setuid root: non-root user: faccessat(readable R_OK AT_EACCESS) is unreadable = FAIL", readable_erok_errno)
+		TEST(writable_ewok == 0, "setuid root: non-root user: faccessat(writable W_OK AT_EACCESS) is unwritable = FAIL", writable_ewok_errno)
+		TEST(executable_exok == 0, "setuid root: non-root user: faccessat(executable X_OK AT_EACCESS) is unexecutable = FAIL", executable_exok_errno)
+		TEST(inaccessible_erok == 0, "setuid root: non-root user: faccessat(inaccessible R_OK AT_EACCESS) is unreadable = FAIL", inaccessible_erok_errno)
+		TEST(inaccessible_ewok == 0, "setuid root: non-root user: faccessat(inaccessible W_OK AT_EACCESS) is unwritable = FAIL", inaccessible_ewok_errno)
+		TEST(inaccessible_exok == -1, "setuid root: non-root user: faccessat(inaccessible X_OK AT_EACCESS) is executable = FAIL", inaccessible_exok_errno)
+	}
+
+	/* Test setuid non-root program */
+	/* Note: Must be setuid, run as non-root other user, linked using absolute path */
+
+	else if (real_uid != 0 && effective_uid != real_uid)
+	{
+		TEST(readable_rok == -1, "setuid non-root: non-root other user: faccessat(readable R_OK) is readable = FAIL", readable_rok_errno)
+		TEST(writable_wok == -1, "setuid non-root: non-root other user: faccessat(writable W_OK) is writable = FAIL", writable_wok_errno)
+		TEST(executable_xok == -1, "setuid non-root: non-root other user: faccessat(executable X_OK) is executable = FAIL", executable_xok_errno)
+		TEST(inaccessible_rok == -1, "setuid non-root: non-root other user: faccessat(inaccessible R_OK) is readable = FAIL", inaccessible_rok_errno)
+		TEST(inaccessible_wok == -1, "setuid non-root: non-root other user: faccessat(inaccessible W_OK) is writable = FAIL", inaccessible_wok_errno)
+		TEST(inaccessible_xok == -1, "setuid non-root: non-root other user: faccessat(inaccessible X_OK) is executable = FAIL", inaccessible_xok_errno)
+		/* This is meaningful because uid != euid */
+		TEST(readable_erok == 0, "setuid non-root: non-root other user: faccessat(readable R_OK AT_EACCESS) is unreadable = FAIL", readable_erok_errno)
+		TEST(writable_ewok == 0, "setuid non-root: non-root other user: faccessat(writable W_OK AT_EACCESS) is unwritable = FAIL", writable_ewok_errno)
+		TEST(executable_exok == 0, "setuid non-root: non-root other user: faccessat(executable X_OK AT_EACCESS) is unexecutable = FAIL", executable_exok_errno)
+		TEST(inaccessible_erok == -1, "setuid non-root: non-root other user: faccessat(inaccessible R_OK AT_EACCESS) is readable = FAIL", inaccessible_erok_errno)
+		TEST(inaccessible_ewok == -1, "setuid non-root: non-root other user: faccessat(inaccessible W_OK AT_EACCESS) is writable = FAIL", inaccessible_ewok_errno)
+		TEST(inaccessible_exok == -1, "setuid non-root: non-root other user: faccessat(inaccessible X_OK AT_EACCESS) is executable = FAIL", inaccessible_exok_errno)
+	}
+
+	/* Report any unexpected situation (won't happen) */
+
+	else
+	{
+		fprintf(stderr, "This uid/euid combination isn't currently tested.\n");
+		++failures;
+	}
+
+	/* Only show the test files and process permissions if there were failures */
+
+	if (failures)
+	{
+		fprintf(stderr, "faccessat_setuid: uid=%s euid=%s gid=%s egid=%s\n",
+			getpwuid(real_uid) ? getpwuid(real_uid)->pw_name : "?",
+			getpwuid(effective_uid) ? getpwuid(effective_uid)->pw_name : "?",
+			getgrgid(real_gid) ? getgrgid(real_gid)->gr_name : "?",
+			getgrgid(effective_gid) ? getgrgid(effective_gid)->gr_name : "?"
+		);
+
+		system("/bin/ls -l test/tmp/*ble");
+	}
+
+	/* Test argument validation */
+
+	int check_pathname_rc = faccessat(AT_FDCWD, NULL, R_OK, 0);
+	int check_pathname_errno = errno;
+	int check_dirfd_rc = faccessat(-1, "pathname", R_OK, 0);
+	int check_dirfd_errno = errno;
+	int check_mode_rc = faccessat(AT_FDCWD, "pathname", -1, 0); // Apple doesn't check this
+	int check_mode_errno = errno;
+	int check_flag_rc = faccessat(AT_FDCWD, "pathname", R_OK, -1);
+	int check_flag_errno = errno;
+
+	TEST(check_pathname_rc == -1, "check pathname failed", 0)
+	if (check_pathname_rc == -1)
+		TEST(check_pathname_errno == EFAULT, "check pathname errno wrong (should be EFAULT)", check_pathname_errno)
+	TEST(check_dirfd_rc == -1, "check dirfd failed", 0)
+	if (check_dirfd_rc == -1)
+		TEST(check_dirfd_errno == EBADF, "check dirfd errno wrong (should be EBADF)", check_dirfd_errno)
+	TEST(check_mode_rc == -1, "check mode failed", 0) // Apple doesn't check this argument - failure is ENOENT/EPERM
+	//if (check_mode_rc == -1)
+	//	TEST(check_mode_errno == EINVAL, "check mode errno wrong (should be EINVAL)", check_mode_errno)
+	if (check_mode_rc == -1) // On 10.14 this is ENOENT. On 10.6 it's EPERM
+		TEST(check_mode_errno == ENOENT || check_mode_errno == EPERM, "check mode errno wrong (should be ENOENT or EPERM)", check_mode_errno)
+	TEST(check_flag_rc == -1, "check flag failed", 0)
+	if (check_flag_rc == -1)
+		TEST(check_flag_errno == EINVAL, "check flag errno wrong (should be EINVAL)", check_flag_errno)
+
+	/* Cleanup */
+
+	unlink(readable_path);
+	unlink(writable_path);
+	unlink(executable_path);
+	unlink(inaccessible_path);
+	if (mkdir_rc == 0)
+		rmdir(TMP);
+
+	/* Delete test/test_faccessat_setuid. Don't wait for make clean. */
+
+	if (real_uid != effective_uid || real_gid != effective_gid)
+		unlink(av[0]);
+
+	return (failures) ? 1 : 0;
+}
+
+/* vi:set noet ts=4 sw=4: */

--- a/test/test_time.cpp
+++ b/test/test_time.cpp
@@ -72,20 +72,6 @@ static void* test_blackhole_thread(void *arg)
   return NULL;
 }
 
-static void* test_wait_thread(void *arg)
-{
-  int c = 0;
-  while ( ++c < 10 )
-  {
-    usleep(100);
-    ::pthread_mutex_lock(&lock);
-    std::cout << "[t2] CLOCK_THREAD_CPUTIME_ID ("<< CLOCK_THREAD_CPUTIME_ID << ") " << time(CLOCK_THREAD_CPUTIME_ID) << std::endl;
-    ::pthread_mutex_unlock(&lock);
-  }
-
-  return NULL;
-}
-
 int main()
 {
   {


### PR DESCRIPTION
This pull request comes from https://github.com/macports/macports-legacy-support/pull/65.

@acjones8 realised that `faccessat` didn't work with `AT_EACCESS`. It just returns -1 with errno set to `EINVAL`. That prevents emacs from installing on old systems. They suggested silently ignoring `AT_EACCESS`.

@catap contributed an approximate implementation to actually implement `AT_EACCESS` instead.

I wrote some tests for `faccessat` and fixed the new implementation.

I realised that the existing `faccessat` implementation didn't actually work at all in setuid/setgid programs where it really matters. It was always checking effective user access, not real user access, which is what `faccessat` is supposed to check by default. So it only works in non-setuid non-setgid programs where the real user and the effective user are the same. This limitation could lead to security flaws in setuid/setgid programs that use `faccessat`.

This pull request replaces the existing incorrect `faccessat` implementation with a new one that mostly works. It includes decent tests, but not super aggressive tests. It tests non-setuid programs and setuid programs (setuid root and setuid non-root user). But it doesn't test setgid programs, or `AT_SYMLINK_NOFOLLOW`, or supplementary groups, or `F_OK`. But those tests can be added later.

This pull request also adds support for `F_OK` which was silently absent before.

It's not completely correct. See `src/atcalls.c` for details. But it's a considerable improvement.

One huge concern I have with this pull request is that it really needs some setuid test programs. And that requires linking via an absolute path to `lib/libMacportsLegacySupport.dylib` rather than via the `@executable_path`.

I have changed the `-L` option in the `Makefile` from `-Llib` to `-L"$(shell pwd)"/lib` expecting it to link via an absolute path, but it didn't work.

If I use `-L/opt/local/lib`, it links via an absolute path, but if I use `-L/Users/raf/src/macports-legacy-support/lib`, it links via `@executable_path` and refuses to load the library. It don't know why it ignores the absolute path I supplied. I thought it might be because `/opt/local/lib` is only writable by `root`, and `/Users/raf/...` isn't, but building in a rootonly-writable directory hierarchy didn't help.

So if anyone can tell me how to get the linker to use an absolute path during testing, it would be able to run all the tests (when run by `root`).

In its current (temporary) state, running `make test` tests `faccessat` only in a non-setuid non-setgid program. It prints:

    Run "sudo make test_faccessat_setuid" to test faccessat properly

If that command is run, then a setuid root test and a setuid non-root user test happen. However, the test programs don't link against the library-being-tested via `@executable_path`. They explicitly link against the library in `/opt/local/lib`.

This can change to use the library-being-tested as soon as we can fix the linking problem for setuid programs.