### PR TITLE
Fix recent dirent.h change

### DIFF
--- a/include/dirent.h
+++ b/include/dirent.h
@@ -61,6 +61,8 @@
 #  define __MPLS_INODE64(sym) __DARWIN_ALIAS(sym)
 #endif
 
+#define __MPLS_ALIAS(sym) __DARWIN_ALIAS(sym)
+
 /* Declare alternative names for the underlying functions for use by the wrappers */
 /* Note: Each __MPLS_ALIAS* macro must match the corresponding __DARWIN_ALIAS* in system <dirent.h> */
 DIR *__mpls_libc_opendir(const char *name) __MPLS_ALIAS_I(opendir);


### PR DESCRIPTION
Oops. Sorry about that. That was a last-minute change to avoid defining `__DARWIN_ALIAS_I` and `__DARWIN_INODE64` when not present which might affect others. Instead, it defines `__MPLS_ALIAS_I` and `__MPLS_INODE64`. I forgot to also define `__MPLS_ALIAS` (which I had used for consistency). That's done now and it works on 10.6.