### PR TITLE
Fix dirent.h clang-devel build failure on 10.9, and 10.4 build failure

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -303,7 +303,7 @@ test_faccessat_setuid: test/test_faccessat
 	@test/do_test_faccessat_setuid "$(BUILDDLIBPATH)"
 
 test_faccessat_setuid_msg:
-	@echo 'Run "sudo make test_faccessat_setuid" to test faccessat properly'
+	@echo 'Run "sudo make test_faccessat_setuid" to test faccessat properly (Not on 10.4)'
 
 $(TESTRUNS): $(TESTRUNPREFIX)%: $(TESTNAMEPREFIX)%
 	$<

--- a/README.md
+++ b/README.md
@@ -41,10 +41,7 @@ Wrapped headers and replaced functions are:
   </tr>
   <tr>
     <td><code>dirent.h</code></td>
-    <td>Adds <code>fdopendir</code> function, and wraps <code>opendir</code>,
-    <code>readdir</code>, <code>readdir_r</code>, <code>rewinddir</code>,
-    <code>seekdir</code>, <code>telldir</code>, <code>dirfd</code>, and
-    <code>closedir</code>, to support <code>fdopendir</code></td>
+    <td>Adds <code>fdopendir</code> function.
     <td>OSX10.9</td>
   </tr>
   <tr>

--- a/include/dirent.h
+++ b/include/dirent.h
@@ -1,7 +1,6 @@
 
 /*
  * Copyright (c) 2019
- * Copyright (C) 2023 raf <raf@raf.org>, Tavian Barnes <tavianator@tavianator.com>
  *
  * Permission to use, copy, modify, and distribute this software for any
  * purpose with or without fee is hereby granted, provided that the above
@@ -22,102 +21,18 @@
 /* MP support header */
 #include "MacportsLegacySupport.h"
 
-/* Alter function names declared by <dirent.h> to get them out of the way */
-/* Note: These renamed names are non-functional */
-#if __MP_LEGACY_SUPPORT_FDOPENDIR__
-#define opendir __mpls_renamed_libc_opendir
-#define closedir __mpls_renamed_libc_closedir
-#define readdir __mpls_renamed_libc_readdir
-#define readdir_r __mpls_renamed_libc_readdir_r
-#define rewinddir __mpls_renamed_libc_rewinddir
-#define seekdir __mpls_renamed_libc_seekdir
-#define telldir __mpls_renamed_libc_telldir
-#endif
-
 /* Include the primary system dirent.h */
 #include_next <dirent.h>
-
-/* Remove the above macros to make way for the declarations below */
-#if __MP_LEGACY_SUPPORT_FDOPENDIR__
-#undef opendir
-#undef closedir
-#undef readdir
-#undef readdir_r
-#undef rewinddir
-#undef seekdir
-#undef telldir
-
-#ifndef __MPLS_ALIAS
-#  define __MPLS_ALIAS(sym) __DARWIN_ALIAS(sym)
-#endif
-
-/* Fallback to __DARWIN_ALIAS if the other variants are not defined (?) */
-/* Note: I don't know if this makes sense */
-#ifndef __MPLS_ALIAS_I
-#  ifdef __DARWIN_ALIAS_I
-#    define __MPLS_ALIAS_I(sym) __DARWIN_ALIAS_I(sym)
-#  else
-#    define __MPLS_ALIAS_I(sym) __DARWIN_ALIAS(sym)
-#  endif
-#endif
-
-#ifndef __MPLS_INODE64
-#  ifdef __DARWIN_INODE64
-#    define __MPLS_INODE64(sym) __DARWIN_INODE64(sym)
-#  else
-#    define __MPLS_INODE64(sym) __DARWIN_ALIAS(sym)
-#  endif
-#endif
-
-/* Declare alternative names for the underlying functions for use by the wrappers */
-/* Note: Each __MPLS_ALIAS* macro must match the corresponding __DARWIN_ALIAS* in system <dirent.h> */
-DIR *__mpls_libc_opendir(const char *name) __MPLS_ALIAS_I(opendir);
-int __mpls_libc_closedir(DIR *dir) __MPLS_ALIAS(closedir);
-struct dirent *__mpls_libc_readdir(DIR *dir) __MPLS_INODE64(readdir);
-int __mpls_libc_readdir_r(DIR *dir, struct dirent *entry, struct dirent **result) __MPLS_INODE64(readdir_r);
-void __mpls_libc_rewinddir(DIR *dir) __MPLS_ALIAS_I(rewinddir);
-void __mpls_libc_seekdir(DIR *dir, long loc) __MPLS_ALIAS_I(seekdir);
-long __mpls_libc_telldir(DIR *dir) __MPLS_ALIAS_I(telldir);
-#endif
 
 /* fdopendir */
 #if __MP_LEGACY_SUPPORT_FDOPENDIR__
 
-/* Wrapper struct for DIR */
-typedef struct __MPLS_DIR __MPLS_DIR;
-struct __MPLS_DIR {
-    DIR *__mpls_dir;
-    int __mpls_dirfd;
-};
-
-#define DIR __MPLS_DIR
-
 __MP__BEGIN_DECLS
 
-extern DIR *fdopendir(int fd) __MPLS_ALIAS_I(fdopendir);
-
-/* Wrapper functions to support fdopendir */
-extern DIR *__mpls_opendir(const char *name);
-extern int __mpls_closedir(DIR *dir);
-extern struct dirent *__mpls_readdir(DIR *dir);
-extern int __mpls_readdir_r(DIR *dir, struct dirent *entry, struct dirent **result);
-extern void __mpls_rewinddir(DIR *dir);
-extern void __mpls_seekdir(DIR *dir, long loc);
-extern long __mpls_telldir(DIR *dir);
-extern int __mpls_dirfd(DIR *dir);
-
-/* Define the standard names to refer to LegacySupport's wrappers (via asm renaming) */
-DIR *opendir(const char *name) __asm("___mpls_opendir");
-int closedir(DIR *dir) __asm("___mpls_closedir");
-struct dirent *readdir(DIR *dir) __asm("___mpls_readdir");
-int readdir_r(DIR *dir, struct dirent *entry, struct dirent **result) __asm("___mpls_readdir_r");
-void rewinddir(DIR *dir) __asm("___mpls_rewinddir");
-void seekdir(DIR *dir, long loc) __asm("___mpls_seekdir");
-long telldir(DIR *dir) __asm("___mpls_telldir");
-
-#ifndef __MP_LEGACY_SUPPORT_NO_DIRFD_MACRO
-#undef dirfd
-#define dirfd(dir) __mpls_dirfd(dir)
+#ifndef __DARWIN_ALIAS_I
+extern DIR *fdopendir(int fd) __DARWIN_ALIAS(fdopendir);
+#else
+extern DIR *fdopendir(int fd) __DARWIN_ALIAS_I(fdopendir);
 #endif
 
 __MP__END_DECLS

--- a/src/fdopendir.c
+++ b/src/fdopendir.c
@@ -22,26 +22,16 @@
 
 #include "common-priv.h"
 
-#define __MP_LEGACY_SUPPORT_NO_DIRFD_MACRO
-
-#include <stdlib.h>
 #include <dirent.h>
-#include <sys/errno.h>
-
-#undef DIR
-
 
 /*
  * Implementation behavior largely follows these man page descriptions:
  *
  * https://www.freebsd.org/cgi/man.cgi?query=fdopendir&sektion=3
  * https://linux.die.net/man/3/fdopendir
- *
- * On success, this function returns allocated memory that must be
- * deallocated by __mpls_closedir() (see closedir() macro in <dirent.h>).
  */
 
-__MPLS_DIR *fdopendir(int dirfd) {
+DIR *fdopendir(int dirfd) {
 
     /* Check dirfd here (for macos-10.4, see _ATCALL() and best_fchdir()) */
 
@@ -50,133 +40,31 @@ __MPLS_DIR *fdopendir(int dirfd) {
         return 0;
     }
 
-    /* Open the supplied directory safely */
+    /* Open given directory fd safely for iteration via readdir */
 
-    DIR *dir = _ATCALL(dirfd, ".", NULL, __mpls_libc_opendir("."));
+    DIR *dir = _ATCALL(dirfd, ".", NULL, opendir("."));
     if (!dir)
         return 0;
 
-    /* Wrap it and return it (with the supplied directory file descriptor) */
+    /* Replace underlying fd with equivalent given fd (closed by closedir) */
 
-    __MPLS_DIR *mplsdir = malloc(sizeof(*mplsdir));
-    if (!mplsdir) {
-        (void)__mpls_libc_closedir(dir);
-        errno = ENOMEM;
-        return 0;
-    }
+    #if __ENVIRONMENT_MAC_OS_X_VERSION_MIN_REQUIRED__ == 1040
+    (void)close(dir->dd_fd);
+    dir->dd_fd = dirfd;
+    #else
+    (void)close(dir->__dd_fd);
+    dir->__dd_fd = dirfd;
+    #endif
 
-    mplsdir->__mpls_dir = dir;
-    mplsdir->__mpls_dirfd = dirfd;
+    /* Rewind to the start of the directory (in case it's not there already) */
 
-    return mplsdir;
-}
+    rewinddir(dir);
 
-/*
- * Wrapped version of opendir() for fdopendir() compatibility
- *
- * On success, this function returns allocated memory that must be
- * deallocated by __mpls_closedir() (see closedir() macro in <dirent.h>).
- */
+    /* Close given fd on exec (just in case not already done) */
 
-__MPLS_DIR *__mpls_opendir(const char *name) {
+    (void)fcntl(dirfd, F_SETFD, FD_CLOEXEC);
 
-    DIR *dir = __mpls_libc_opendir(name);
-    if (!dir)
-        return 0;
-
-    __MPLS_DIR *mplsdir = malloc(sizeof(*mplsdir));
-    if (!mplsdir) {
-        (void)__mpls_libc_closedir(dir);
-        errno = ENOMEM;
-        return 0;
-    }
-
-    mplsdir->__mpls_dir = dir;
-    mplsdir->__mpls_dirfd = -1;
-
-    return mplsdir;
-}
-
-/*
- * Wrapped version of closedir() for fdopendir() compatibility (see
- * closedir() macro in <dirent.h>).
- *
- * This function deallocates memory that was allocated by fdopendir() or
- * __mpls_opendir().
- */
-
-int __mpls_closedir(__MPLS_DIR *mplsdir) {
-
-    if (!mplsdir) {
-        errno = EBADF;
-        return -1;
-    }
-
-    int rc = __mpls_libc_closedir(mplsdir->__mpls_dir);
-
-    if (mplsdir->__mpls_dirfd != -1)
-        PROTECT_ERRNO(close(mplsdir->__mpls_dirfd));
-
-    free(mplsdir);
-
-    return rc;
-}
-
-/*
- * Wrapped version of readdir() for fdopendir() compatibility.
- */
-
-struct dirent *__mpls_readdir(__MPLS_DIR *mplsdir) {
-    return __mpls_libc_readdir(mplsdir->__mpls_dir);
-}
-
-/*
- * Wrapped version of readdir_r() for fdopendir() compatibility.
- */
-
-int __mpls_readdir_r(__MPLS_DIR *mplsdir, struct dirent *entry, struct dirent **result) {
-    return __mpls_libc_readdir_r(mplsdir->__mpls_dir, entry, result);
-}
-
-/*
- * Wrapped version of rewinddir() for fdopendir() compatibility.
- */
-
-void __mpls_rewinddir(__MPLS_DIR *mplsdir) {
-    __mpls_libc_rewinddir(mplsdir->__mpls_dir);
-}
-
-/*
- * Wrapped version of seekdir() for fdopendir() compatibility.
- */
-
-void __mpls_seekdir(__MPLS_DIR *mplsdir, long loc) {
-    __mpls_libc_seekdir(mplsdir->__mpls_dir, loc);
-}
-
-/*
- * Wrapped version of telldir() for fdopendir() compatibility.
- */
-
-long __mpls_telldir(__MPLS_DIR *mplsdir) {
-    return __mpls_libc_telldir(mplsdir->__mpls_dir);
-}
-
-/*
- * Wrapped version of dirfd() for fdopendir() compatibility because dirfd()
- * itself is already a macro (see dirfd() macro in <dirent.h>).
- */
-
-int __mpls_dirfd(__MPLS_DIR *mplsdir) {
-
-    /* Return the supplied directory file descriptor if there was one */
-
-    if (mplsdir->__mpls_dirfd != -1)
-        return mplsdir->__mpls_dirfd;
-
-    /* Otherwise call the underlying dirfd() macro */
-
-    return dirfd(mplsdir->__mpls_dir);
+    return dir;
 }
 
 #endif /* __MP_LEGACY_SUPPORT_FDOPENDIR__ */

--- a/test/do_test_faccessat_setuid
+++ b/test/do_test_faccessat_setuid
@@ -16,6 +16,9 @@
 
 # When run as root, test faccessat() properly
 
+# Note: On 10.4, this doesn't work because setreuid/setregid are incorrect.
+# They set effective uid/gid, but not real uid/gid.
+
 if [ "$(whoami)" != root ]
 then
 	echo 'Run "sudo make test_faccessat_setuid" to test faccessat properly'
@@ -60,24 +63,32 @@ clean()
 	rm -rf $s $t
 }
 
-get_group()
+get_group() # Get the user's primary group name
 {
 	echo $(id $1 | sed -E 's/^.*gid=-?[0-9]+\(//; s/\).*$//')
 }
 
-get_supp_group()
+get_supp_group() # Get the user's first supplementary group name, if any
 {
-	echo $(id $1 | sed -E 's/^.*groups=-?[0-9]+\([^)]+\),-?[0-9]+\(//; s/\).*$//')
+	echo $(id $1 | sed -E '
+		s/^uid=-?[0-9]+\([^)]+\) //;
+		s/^gid=-?[0-9]+\([^)]+\) //;
+		s/^groups=-?[0-9]+\([^)]+\)//;
+		s/^,//;
+		s/,.*$//;
+		s/^-?[0-9]+\(//;
+		s/\)$//
+	')
 }
 
-uucp_group=$(get_group _uucp)
+daemon_group=$(get_group daemon)
 nobody_group=$(get_group nobody)
 nobody_supp_group=$(get_supp_group nobody)
 
-# Run normal test as setuid _uucp (to test AT_EACCESS)
+# Run normal test as setuid daemon (to test AT_EACCESS)
 
-echo setuid _uucp
-setup _uucp $uucp_group 4755
+echo setuid daemon
+setup daemon $daemon_group 4755
 check sudo -u nobody $s
 clean
 
@@ -91,20 +102,20 @@ clean
 # Test different numbers of leading dirs and leading dirs with different
 # permissions (to test leading executable check)
 
-setup _uucp $uucp_group 4755
-setid _uucp $uucp_group 644 $t/f touch
-setid _uucp $uucp_group 755 $t/d1 mkdir
-setid _uucp $uucp_group 000 $t/d2 mkdir
-setid _uucp $uucp_group 644 $t/d1/f touch
-setid _uucp $uucp_group 644 $t/d2/f touch
+setup daemon $daemon_group 4755
+setid daemon $daemon_group 644 $t/f touch
+setid daemon $daemon_group 755 $t/d1 mkdir
+setid daemon $daemon_group 000 $t/d2 mkdir
+setid daemon $daemon_group 644 $t/d1/f touch
+setid daemon $daemon_group 644 $t/d2/f touch
 
-echo leading dirs ruid=nobody euid=_uucp
+echo leading dirs ruid=nobody euid=daemon
 check sudo -u nobody $s test test/ \
 	$t $t/ $t/f \
 	$t/d1 $t/d1/ $t/d1/f \
 	$t/d2 $t/d2/ $t/d2/f
 
-echo leading dirs ruid=root euid=_uucp
+echo leading dirs ruid=root euid=daemon
 check $s test test/ \
 	$t $t/ $t/f \
 	$t/d1 $t/d1/ $t/d1/f \
@@ -152,32 +163,35 @@ checkperms nobody $nobody_group 755
 # (to test when uid/gid don't match)
 
 echo perm diff user
-checkperms _uucp $uucp_group 755
+checkperms daemon $daemon_group 755
 
 # Test lots of permissions without setuid/setgid with different user's files
 # but the same group (to test when uid doesn't match but gid does match)
 
 echo perm same group
-checkperms _uucp $nobody_group 755
+checkperms daemon $nobody_group 755
 
 # Test lots of permissions without setuid/setgid with different user's files
 # but same supplementary group (to test when uid/gid don't match but a
 # supplementary group matches)
 
-echo perm same supp group
-checkperms _uucp $nobody_supp_group 755
+if [ -n "$nobody_supp_group" ]
+then
+	echo perm same supp group
+	checkperms daemon $nobody_supp_group 755
+fi
 
 # Test lots of permissions with setuid with different user's files
 # (to test setuid)
 
-echo perm setuid _uucp
-checkperms _uucp $uucp_group 4755
+echo perm setuid daemon
+checkperms daemon $daemon_group 4755
 
 # Test lots of permissions with setgid with different user's files
 # (to test setgid)
 
-echo perm setgid _uucp
-checkperms _uucp $uucp_group 2755
+echo perm setgid daemon
+checkperms daemon $daemon_group 2755
 
 exit $fail
 

--- a/test/test_faccessat.c
+++ b/test/test_faccessat.c
@@ -351,8 +351,8 @@ int main(int ac, char **av)
 	if (check_pathname_rc == -1)
 		TEST(check_pathname_errno == EFAULT, "check pathname errno wrong (should be EFAULT)", check_pathname_errno)
 	TEST(check_dirfd_rc == -1, "check dirfd failed", 0)
-	if (check_dirfd_rc == -1)
-		TEST(check_dirfd_errno == EBADF, "check dirfd errno wrong (should be EBADF)", check_dirfd_errno)
+	if (check_dirfd_rc == -1) // On 10.14 this is EBADF. On 10.4 it's ENOENT
+		TEST(check_dirfd_errno == EBADF || check_dirfd_errno == ENOENT, "check dirfd errno wrong (should be EBADF or ENOENT)", check_dirfd_errno)
 	TEST(check_mode_rc == -1, "check mode failed", 0) // Apple doesn't check this argument - failure is ENOENT/EPERM
 	//if (check_mode_rc == -1)
 	//	TEST(check_mode_errno == EINVAL, "check mode errno wrong (should be EINVAL)", check_mode_errno)


### PR DESCRIPTION
Originally, fdopendir was declared in dirent.h
using __DARWIN_ALIAS_I. I think this was needed
because the original implementation had local
variables of type struct statbuf, and so its
translation unit needed to be compiled multiple
times, once for each inode size, and each version
would be differently labelled, and __DARWIN_ALIAS_I
was probably needed to select the correctly
labelled version of fdopendir. But I am guessing.

The current implementation no longer uses any
struct statbuf local variables, and so is only
compiled once. I think this means that it is no
longer necessary to use __DARWIN_ALIAS_I when
declaring fdopendir. Perhaps surprisingly, it
still worked with __DARWIN_ALIAS_I in place.
So maybe I'm guessing wrong.

However, the clang-devel port failed to compile
on macOS-10.9, complaining about the attempt to
overload a function (fdopendir) that differed only
in return type (i.e., LegacySupport's wrapper DIR
struct, as opposed to the system DIR struct). And
maybe I've misunderstood the error message. And
this compiler error didn't appear on other legacy
platforms. So the problem isn't definitely understood.

I might be wrong about why and when __DARWIN_ALIAS_I
is needed, but it seemed that it possibly isn't needed
anymore (if it ever was).

This patch stops declaring fdopendir via __DARWIN_ALIAS_I
and it doesn't break LegacySupport on macOS-10.6 at least.
It compiles and the tests pass. If it works on other legacy
platforms, this should fix clang-devel's build failure by
eliminating the attempt to overload fdopendir.