### PR TITLE
Makefile: fix fdopendir

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -84,7 +84,7 @@ FIND_LIBHEADERS := find $(SRCINCDIR) -type f \( -name '*.h' -o \
 LIBHEADERS      := $(shell $(FIND_LIBHEADERS))
 ALLHEADERS      := $(LIBHEADERS) $(wildcard $(SRCDIR)/*.h)
 
-MULTISRCS       := # Used to have $(SRCDIR)/fdopendir.c because it used struct stat
+MULTISRCS       := $(SRCDIR)/fdopendir.c
 ADDSRCS         := $(SRCDIR)/add_symbols.c
 LIBSRCS         := $(filter-out $(MULTISRCS) $(ADDSRCS),$(wildcard $(SRCDIR)/*.c))
 


### PR DESCRIPTION
This reverts an earlier change to Makefile which led to needed `_fdopendir*` symbols being missing from the `legacy-support` dylib.
See https://github.com/macports/macports-ports/pull/22617#issuecomment-1937102831

@kencu @macportsraf @mascguy @cjones051073 @catap 