### PR TITLE
Fix some expected fdopendir() failures, plus some other cleanups

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 *.o
+*.o.*
 *.d
 *.dylib
 lib
 *~
+*.dSYM

--- a/src/fdopendir.c
+++ b/src/fdopendir.c
@@ -24,6 +24,10 @@
 
 #include <dirent.h>
 
+#if __ENVIRONMENT_MAC_OS_X_VERSION_MIN_REQUIRED__ < 1050
+#define __dd_fd dd_fd
+#endif /* __ENVIRONMENT_MAC_OS_X_VERSION_MIN_REQUIRED__ < 1050 */
+
 /*
  * Implementation behavior largely follows these man page descriptions:
  *
@@ -51,13 +55,8 @@ DIR *fdopendir(int dirfd) {
      * A subsequent closedir() will close dirfd
      */
 
-    #if __ENVIRONMENT_MAC_OS_X_VERSION_MIN_REQUIRED__ == 1040
-    (void)close(dir->dd_fd);
-    dir->dd_fd = dirfd;
-    #else
     (void)close(dir->__dd_fd);
     dir->__dd_fd = dirfd;
-    #endif
 
     /*
      * Rewind to the start of the directory, in case the underlying file

--- a/src/fdopendir.c
+++ b/src/fdopendir.c
@@ -46,7 +46,10 @@ DIR *fdopendir(int dirfd) {
     if (!dir)
         return 0;
 
-    /* Replace underlying fd with equivalent given fd (closed by closedir) */
+    /*
+     * Replace underlying fd with supplied dirfd
+     * A subsequent closedir() will close dirfd
+     */
 
     #if __ENVIRONMENT_MAC_OS_X_VERSION_MIN_REQUIRED__ == 1040
     (void)close(dir->dd_fd);
@@ -56,11 +59,14 @@ DIR *fdopendir(int dirfd) {
     dir->__dd_fd = dirfd;
     #endif
 
-    /* Rewind to the start of the directory (in case it's not there already) */
+    /*
+     * Rewind to the start of the directory, in case the underlying file
+     * is not positioned at the start
+     */
 
     rewinddir(dir);
 
-    /* Close given fd on exec (just in case not already done) */
+    /* Close given fd on exec (as per fdopendir() docs) */
 
     (void)fcntl(dirfd, F_SETFD, FD_CLOEXEC);
 

--- a/test/.gitignore
+++ b/test/.gitignore
@@ -1,7 +1,5 @@
-test_arc4random
-test_cmath_cxx03
-test_cmath_cxx11
-test_realpath
-test_sysconf
-test_time
-test_wcscasecmp
+*
+!*.c
+!*.cc
+!*.cpp
+!do_test_faccessat_setuid

--- a/test/test_fdopendir.c
+++ b/test/test_fdopendir.c
@@ -26,8 +26,6 @@
 #include <stdio.h>
 #include <string.h>
 
-#define FEEDBACK 1
-
 /* Test expected failure case */
 
 int check_failure(int fd, const char *name, const char *exp_sym, int exp_val)
@@ -87,7 +85,7 @@ int main() {
             return 1;
         }
 
-#if FEEDBACK
+#ifdef FEEDBACK
         printf("%s\n", entry->d_name);
 #endif
     }


### PR DESCRIPTION
This was triggered by noticing that the fdopendir(stdin) test was failing (due to returning the wrong errno) when run from a pipe rather than a tty or pty.  This led to adding two more tests, which in turn led to finding additional bugs.  These bugs are fixed here, and the commit order is rearranged to put the fixes before the test additions, to avoid creating a pothole in the history.

There are also some additional cleanups, both related and unrelated, as separate commits.

See the individual commit messages for more information.

This has been tested on all non-oddball platforms except 13.x+ x86_64, as well as on 10.4 x86_64 (which tends to be a problem case).  Building and testing "bare" in this repo (non-universal only) successfully builds and passes tests on all such platforms.  Building and testing in the `legacy-support-devel` context has some failures, but these are the same failures with and without this PR, and are unrelated to fdopendir().

Tested on:
```
Mac OS X 10.4.11 8S165, PPC, Xcode 2.5 8M2558
Mac OS X 10.4.11 8S2167, i386, Xcode 2.5 8M2558
Mac OS X 10.4.11 8S2167, x86_64, Xcode 2.5 8M2558
Mac OS X 10.5.8 9L31a, PPC, Xcode 3.1.4 9M2809
Mac OS X 10.5.8 9L31a, i386, Xcode 3.1.4 9M2809
Mac OS X 10.5.8 9L31a, x86_64, Xcode 3.1.4 9M2809
Mac OS X 10.6.8 10K549, i386, Xcode 3.2.6 10M2518
Mac OS X 10.6.8 10K549, x86_64, Xcode 3.2.6 10M2518
Mac OS X 10.7.5 11G63, x86_64, Xcode 4.6.3 4H1503
OS X 10.8.5 12F2560, x86_64, Xcode 5.1.1 5B1008
OS X 10.9.5 13F1911, x86_64, Xcode 6.2 6C131e
OS X 10.10.5 14F2511, x86_64, Xcode 7.2 7C68
OS X 10.11.6 15G22010, x86_64, Xcode 8.1 8B62
macOS 10.12.6 16G2136, x86_64, Xcode 9.2 9C40b
macOS 10.13.6 17G14042, x86_64, Xcode 10.1 10B61
macOS 10.14.6 18G9323, x86_64, Xcode 11.3.1 11C505
macOS 10.15.7 19H15, x86_64, Xcode 12.4 12D4e
macOS 11.7.10 20G1427, x86_64, Xcode 13.2.1 13C100
macOS 11.7.10 20G1427, arm64, Xcode 13.2.1 13C100
macOS 12.7.3 21H1015, x86_64, Xcode 14.2 14C18
macOS 12.7.3 21H1015, arm64, Xcode 14.2 14C18
macOS 13.6.4 22G513, arm64, Xcode 15.2 15C500b
macOS 14.3.1 23D60, arm64, Xcode 15.2 15C500b
```
