### PR TITLE
Add compatibility entries for obsolete __mpls_* funcs.

### DIFF
--- a/src/dirfuncs_compat.c
+++ b/src/dirfuncs_compat.c
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) 2024 Frederick H. G. Wright II <fw@fwright.net>
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
+/*
+ * Earlier versions of legacy-support needed wrappers around several OS
+ * calls related to directories, in order to implement fdopendir().  That
+ * is no longer the case, but existing dependents still reference those
+ * wrapper calls.  For compatibility, we continue to provide those functions,
+ * but just as transparent wrappers around the OS calls.
+ *
+ * This is only relevant for OS versions where our fdoopendir() is needed,
+ * hence the conditional (which is the same conditional as was used for
+ * the earlier implementations).
+ */
+
+/* MP support header */
+#include "MacportsLegacySupport.h"
+#if __MP_LEGACY_SUPPORT_FDOPENDIR__
+
+#include "dirfuncs_compat.h"
+
+DIR *
+__mpls_opendir(const char *filename) {
+    return opendir(filename);
+}
+
+struct dirent *
+__mpls_readdir(DIR *dirp) {
+    return readdir(dirp);
+}
+
+int
+__mpls_readdir_r(DIR *dirp, struct dirent *entry, struct dirent **result) {
+    return readdir_r(dirp, entry, result);
+}
+
+long
+__mpls_telldir(DIR *dirp) {
+    return telldir(dirp);
+}
+
+void
+__mpls_seekdir(DIR *dirp, long loc) {
+    seekdir(dirp, loc);
+}
+
+void
+__mpls_rewinddir(DIR *dirp) {
+    rewinddir(dirp);
+}
+
+int
+__mpls_closedir(DIR *dirp) {
+    return closedir(dirp);
+}
+
+int
+__mpls_dirfd(DIR *dirp) {
+    return dirfd(dirp);
+}
+
+#endif /* __MP_LEGACY_SUPPORT_FDOPENDIR__ */

--- a/src/dirfuncs_compat.h
+++ b/src/dirfuncs_compat.h
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2024 Frederick H. G. Wright II <fw@fwright.net>
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
+/* Prototypes for directory function compatibility wrappers */
+
+#ifndef __MP_LEGACY_SUPPORT_DIRFUNCS_COMPAT_H
+#define __MP_LEGACY_SUPPORT_DIRFUNCS_COMPAT_H
+
+#include <dirent.h>
+
+DIR *
+__mpls_opendir(const char *filename);
+
+struct dirent *
+__mpls_readdir(DIR *dirp);
+
+int
+__mpls_readdir_r(DIR *dirp, struct dirent *entry, struct dirent **result);
+
+long
+__mpls_telldir(DIR *dirp);
+
+void
+__mpls_seekdir(DIR *dirp, long loc);
+
+void
+__mpls_rewinddir(DIR *dirp);
+
+int
+__mpls_closedir(DIR *dirp);
+
+int
+__mpls_dirfd(DIR *dirp);
+
+#endif /* __MP_LEGACY_SUPPORT_DIRFUNCS_COMPAT_H */

--- a/test/test_dirfuncs_compat.c
+++ b/test/test_dirfuncs_compat.c
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2024 Frederick H. G. Wright II <fw@fwright.net>
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
+/*
+ * This leverages the existing tests for the old __mpls_* wrappers as tests
+ * for the new transparent wrappers provided for compatibility, by defining
+ * the relevant functions as macros and reusing all of test_fdopendir.
+ *
+ * For OS versions that never used the wrappers, this entire test is a dummy.
+ */
+
+/* MP support header */
+#include "MacportsLegacySupport.h"
+#if __MP_LEGACY_SUPPORT_FDOPENDIR__
+
+#include "../src/dirfuncs_compat.h"
+
+#define opendir     __mpls_opendir
+#define readdir     __mpls_readdir
+#define readdir_r   __mpls_readdir_r
+#define telldir     __mpls_telldir
+#define seekdir     __mpls_seekdir
+#define rewinddir   __mpls_rewinddir
+#define closedir    __mpls_closedir
+#define dirfd       __mpls_dirfd
+
+#include "test_fdopendir.c"
+
+#else /* !__MP_LEGACY_SUPPORT_FDOPENDIR__ */
+
+int main(){ return 0; }
+
+#endif /* !__MP_LEGACY_SUPPORT_FDOPENDIR__ */

--- a/test/test_fdopendir.c
+++ b/test/test_fdopendir.c
@@ -90,7 +90,14 @@ int main() {
 #endif
     }
 
-    /* Test wrapper functions/macros (all but readdir_r which is deprecated) */
+    /*
+     * Test wrapper functions/macros (all but readdir_r which is deprecated)
+     *
+     * Although the wrapper functions that these tests were originally
+     * intended for no longer exist, these same tests are also used to
+     * check the transparent wrappers added for compatibility with old
+     * client builds.
+     */
 
     int dfd2 = dirfd(dir);
     if (dfd2 != dfd) {


### PR DESCRIPTION
The __mpls_* wrappers are no longer needed for the new fdopendir() implementation, but many existing dependents may still have references to them.  This adds those functions back as transparent wrappers for the corresponding OS calls.

This also adds tests for the wrappers, by applying the existing tests (in test_fdopendir) to the wrappers via macro replacements.

TESTED:
Tested on 10.4-10.5 ppc, 10.5-10.6 ppc (x86_64 Rosetta), 10.4-10.6 i386, 10.4-12.x x86_64, and 11.x-14.x arm64.
Builds on all tested platforms except 10.5 ppc +universal, and passes all tests in all buildable cases, including the new tests. Comparison with "nm" shows that no global definitions were removed from the libraries since v1.1.1, with additions as needed for the new fdopendir(), and no differences at all for OS 10.10+.