### PR TITLE
dirfuncs_compat: Add comment regarding retention.

### DIFF
--- a/include/time.h
+++ b/include/time.h
@@ -85,7 +85,7 @@ extern int clock_getres ( clockid_t clk_id, struct timespec *ts );
 
 __MP__END_DECLS
 
-#endif /* _MP_LEGACY_SUPPORT_GETTIME__ */
+#endif /* __MP_LEGACY_SUPPORT_GETTIME__ */
 
 /* Legacy implementation of timespec */
 #if __MP_LEGACY_SUPPORT_TIMESPEC_GET__

--- a/src/dirfuncs_compat.c
+++ b/src/dirfuncs_compat.c
@@ -21,7 +21,13 @@
  * wrapper calls.  For compatibility, we continue to provide those functions,
  * but just as transparent wrappers around the OS calls.
  *
- * This is only relevant for OS versions where our fdoopendir() is needed,
+ * These wrappers can eventually be removed once all dependents have been
+ * rebuilt with the current headers.  But since there would be significant
+ * work in determining when this is the case, and since they only add 752
+ * bytes to the library size, they should probably be left in place for a
+ * long time.
+ *
+ * This is only relevant for OS versions where our fdopendir() is needed,
  * hence the conditional (which is the same conditional as was used for
  * the earlier implementations).
  */


### PR DESCRIPTION
Also corrects typo in same comment.

Also corrects typo in unrelated comment in time.h.