### PR TITLE
sysconf(_SC_PHYS_PAGES): Always use wrapper on i386

### DIFF
--- a/include/MacportsLegacySupport.h
+++ b/include/MacportsLegacySupport.h
@@ -118,8 +118,9 @@
 /* sys/aio.h header needs adjustment to match newer SDKs */
 #define __MP_LEGACY_SUPPORT_SYSAIOTIGERFIX__  (__APPLE__ && __ENVIRONMENT_MAC_OS_X_VERSION_MIN_REQUIRED__ < 1050)
 
-/*  sysconf() is missing some functions on some systems */
-#define __MP_LEGACY_SUPPORT_SYSCONF_WRAP__    (__APPLE__ && __ENVIRONMENT_MAC_OS_X_VERSION_MIN_REQUIRED__ < 101100)
+/*  sysconf() is missing some functions on some systems, and may misbehave on i386 */
+#define __MP_LEGACY_SUPPORT_SYSCONF_WRAP__    (__APPLE__ && (__ENVIRONMENT_MAC_OS_X_VERSION_MIN_REQUIRED__ < 101100 \
+                                                             || defined(__i386)))
 
 /* pthread_rwlock_initializer is not defined on Tiger */
 #define __MP_LEGACY_SUPPORT_PTHREAD_RWLOCK__  (__APPLE__ && __ENVIRONMENT_MAC_OS_X_VERSION_MIN_REQUIRED__ < 1050)

--- a/include/unistd.h
+++ b/include/unistd.h
@@ -92,10 +92,13 @@
 #define __MP_LEGACY_SUPPORT_SYSCONF_WRAP_NEED_SC_NPROCESSORS_ONLN__ 1
 #endif
 
+/* The OS-provided version of this item doesn't work properly on i386 */
+#if !defined(_SC_PHYS_PAGES) || defined (__i386__)
 #ifndef _SC_PHYS_PAGES
 #define _SC_PHYS_PAGES 200
-#define __MP_LEGACY_SUPPORT_SYSCONF_WRAP_NEED_SC_PHYS_PAGES__ 1
 #endif
+#define __MP_LEGACY_SUPPORT_SYSCONF_WRAP_NEED_SC_PHYS_PAGES__ 1
+#endif /* !defined(_SC_PHYS_PAGES) || defined (__i386__) */
 
 #if __MP_LEGACY_SUPPORT_FSETATTRLIST__
 


### PR DESCRIPTION
Apple's implementation of sysconf(_SC_PHYS_PAGES) never worked on i386.  It wasn't provided until 10.11, which requires x86_64, so the problem is never seen in ordinary native builds.  It is visible in i386 builds for 10.11+, including universal builds with i386.  Since MacPorts dropped i386 from the default universal_archs in 10.14, it's not normally seen in 10.14+.  It can be seen in the test failures in the 10.11-10.13 +universal cases.

The fix is simply to use the working legacy-support implementation in all i386 builds, regardless of OS version.

TESTED:
Tested on 10.4-10.5 ppc, 10.5-10.6 ppc (x86_64 Rosetta), 10.4-10.6 i386, 10.4-12.x x86_64, and 11.x-14.x arm64.
Builds on all tested platforms except 10.4 ppc +universal, and passes all tests in all buildable cases, including the previously failing 10.11-10.13 +universal tests.