### PR TITLE
sys/socket.h: Fix CMSG_DATA definition in <10.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,11 @@ Wrapped headers and replaced functions are:
     <td>OSX10.11</td>
   </tr>
   <tr>
+    <td><code>sys/socket.h</code></td>
+    <td>Corrects <code>CMSG_DATA</code> definition</td>
+    <td>OSX10.5</td>
+  </tr>
+  <tr>
     <td><code>sys/time.h</code></td>
     <td>Adds <code>lutimes</code> function</td>
     <td>OSX10.4</td>

--- a/include/MacportsLegacySupport.h
+++ b/include/MacportsLegacySupport.h
@@ -58,6 +58,9 @@
 /* <net/if.h> include <sys/socket.h> */
 #define __MP_LEGACY_SUPPORT_NETIF_SOCKET_FIX__  (__APPLE__ && __ENVIRONMENT_MAC_OS_X_VERSION_MIN_REQUIRED__ < 1090)
 
+/* CMSG_DATA definition in <sys/socket.h> */
+#define __MP_LEGACY_SUPPORT_CMSG_DATA_FIX__  (__APPLE__ && __ENVIRONMENT_MAC_OS_X_VERSION_MIN_REQUIRED__ < 1060)
+
 /* strnlen */
 #define __MP_LEGACY_SUPPORT_STRNLEN__         (__APPLE__ && __ENVIRONMENT_MAC_OS_X_VERSION_MIN_REQUIRED__ < 1070)
 

--- a/include/sys/socket.h
+++ b/include/sys/socket.h
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2024 Frederick H. G. Wright II <fw@fwright.net>
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
+#ifndef _MACPORTS_SYS_SOCKET_H_
+#define _MACPORTS_SYS_SOCKET_H_
+
+/* MP support header */
+#include "MacportsLegacySupport.h"
+
+/* Include the primary system sys/socket.h */
+#include_next <sys/socket.h>
+
+/*
+ * OSX prior to 10.6 defines CMSG_DATA without properly considering 64-bit
+ * builds, due to bad alignment assumptions, though it happens to work in
+ * the 10.4 case and only actually fails in the 10.5 64-bit case.
+ *
+ * In those OS versions we substitute a version of the definition from 10.6.
+ */
+
+#if __MP_LEGACY_SUPPORT_CMSG_DATA_FIX__
+
+#define	__DARWIN_ALIGNBYTES32 (sizeof(__uint32_t) - 1)
+#define	__DARWIN_ALIGN32(p) \
+	((size_t)((char *)(size_t)(p) \
+	 + __DARWIN_ALIGNBYTES32) &~ __DARWIN_ALIGNBYTES32)
+
+/* given pointer to struct cmsghdr, return pointer to data */
+#undef CMSG_DATA
+#define	CMSG_DATA(cmsg) ((unsigned char *)(cmsg) + \
+	__DARWIN_ALIGN32(sizeof(struct cmsghdr)))
+
+#endif /* __MP_LEGACY_SUPPORT_CMSG_DATA_FIX__ */
+
+#endif /* _MACPORTS_SYS_SOCKET_H_ */

--- a/test/test_cmsg_macro.c
+++ b/test/test_cmsg_macro.c
@@ -1,0 +1,24 @@
+/*
+ * Test for CMSG_DATA() macro
+ */
+
+#include <stdio.h>
+#include <sys/socket.h>
+#include <assert.h>
+
+const static struct {
+  struct cmsghdr  hdr;
+  unsigned char   data[4];
+} test = {{0}};
+
+int
+main()
+{
+  const unsigned char *testb = (const unsigned char *) &test;
+  int real_ofs = &test.data[0] - testb;
+  int macro_ofs = CMSG_DATA(&test) - testb;
+
+  assert(macro_ofs == real_ofs);
+  printf("CMSG_DATA offset = %d\n", macro_ofs);
+  return 0;
+}


### PR DESCRIPTION
This is two commits - one to fix the issue, and one to add the test.  See the individual commit messages for more details.
