### PR TITLE
__MP_LEGACY_SUPPORT_SYSCONF_WRAP__: fix nested macro expansion warning

### DIFF
--- a/include/MacportsLegacySupport.h
+++ b/include/MacportsLegacySupport.h
@@ -30,6 +30,12 @@
 #define	__MP__END_DECLS
 #endif
 
+/* foundational defs, used later */
+
+#if defined(__i386)
+#define __MP_LEGACY_SUPPORT_I386__
+#endif
+
 /* defines for when legacy support is required for various functions */
 
 /* fsgetpath */
@@ -123,7 +129,7 @@
 
 /*  sysconf() is missing some functions on some systems, and may misbehave on i386 */
 #define __MP_LEGACY_SUPPORT_SYSCONF_WRAP__    (__APPLE__ && (__ENVIRONMENT_MAC_OS_X_VERSION_MIN_REQUIRED__ < 101100 \
-                                                             || defined(__i386)))
+                                                             || __MP_LEGACY_SUPPORT_I386__))
 
 /* pthread_rwlock_initializer is not defined on Tiger */
 #define __MP_LEGACY_SUPPORT_PTHREAD_RWLOCK__  (__APPLE__ && __ENVIRONMENT_MAC_OS_X_VERSION_MIN_REQUIRED__ < 1050)


### PR DESCRIPTION
Minor fix for warning:

```
src/macports_legacy_sysconf.c:21:5: warning: macro expansion producing 'defined' has undefined behavior [-Wexpansion-to-defined]
#if __MP_LEGACY_SUPPORT_SYSCONF_WRAP__
    ^
include/MacportsLegacySupport.h:126:65: note: expanded from macro '__MP_LEGACY_SUPPORT_SYSCONF_WRAP__'
                                                             || defined(__i386)))
                                                                ^
```

See: https://github.com/macports/macports-legacy-support/pull/75#discussion_r1531006443

CC: @fhgwright