### PR TITLE
__MP_LEGACY_SUPPORT_I386__: define unconditionally, as a one/zero boolean

### DIFF
--- a/include/MacportsLegacySupport.h
+++ b/include/MacportsLegacySupport.h
@@ -33,7 +33,9 @@
 /* foundational defs, used later */
 
 #if defined(__i386)
-#define __MP_LEGACY_SUPPORT_I386__
+#define __MP_LEGACY_SUPPORT_I386__            1
+#else
+#define __MP_LEGACY_SUPPORT_I386__            0
 #endif
 
 /* defines for when legacy support is required for various functions */


### PR DESCRIPTION
Minor fix necessary, due to an oversight by Yours Truly. Resolves build failures for 32-bit/i386.

See: https://github.com/macports/macports-legacy-support/pull/75
See: https://github.com/macports/macports-legacy-support/pull/77

CC: @fhgwright 