### PR TITLE
test_dirfuncs_compat: Fix warning

### DIFF
--- a/test/test_dirfuncs_compat.c
+++ b/test/test_dirfuncs_compat.c
@@ -35,6 +35,7 @@
 #define seekdir     __mpls_seekdir
 #define rewinddir   __mpls_rewinddir
 #define closedir    __mpls_closedir
+#undef dirfd
 #define dirfd       __mpls_dirfd
 
 #include "test_fdopendir.c"


### PR DESCRIPTION
Since dirfd() may be defined as a macro, it needs to be undefined before defining it, to avoid a warning.

TESTED:
Tested on 10.4-10.5 ppc, 10.4-10.6 i386, 10.5-10.6 ppc (i386 Rosetta), 10.5-12.x x86_64, 11.x-14.x arm64.
Redfinition warning is now gone.