### PR TITLE
stpncpy: Fix potential header collision with "later" SDK

### DIFF
--- a/include/string.h
+++ b/include/string.h
@@ -27,6 +27,7 @@
 /* stpncpy */
 #if __MP_LEGACY_SUPPORT_STPNCPY__
 __MP__BEGIN_DECLS
+#undef stpncpy  /* In case built with later SDK */
 extern char *stpncpy(char *dst, const char *src, size_t n);
 __MP__END_DECLS
 #endif


### PR DESCRIPTION
This is one case of the general problem in:

https://trac.macports.org/ticket/69867

This should fix the only known case specifically related to collisions with "secure" wrappers.  Whether there are other types of SDK collisions is TBD.

TESTED:
Builds and passes tests on 10.4-10.5 ppc, 10.4-10.6 i386, 10.5-10.6 ppc (i386 Rosetta), 10.5-12.x x86_64, 11.x-14.x arm64. Builds test_stpncpy successfully on 10.6 with 10.7 SDK.