### PR TITLE
Add fgetattrlist()

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,7 +199,8 @@ Wrapped headers and replaced functions are:
     <td rowspan="3"><code>sys/unistd.h</code></td>
     <td>Adds <code>getattrlistat</code>, <code>readlinkat</code>, <code>faccessat</code>,
         <code>fchownat</code>, <code>linkat</code>, <code>symlinkat</code>,
-        and <code>unlinkat</code> functions</td>
+        <code>unlinkat</code></td>,
+        <code>fsetattrlist</code>, and <code>fgetattrlist</code> functions.
     <td>OSX10.9</td>
   </tr>
   <tr>

--- a/include/MacportsLegacySupport.h
+++ b/include/MacportsLegacySupport.h
@@ -222,7 +222,7 @@
 /*  realpath() on < 10.6 does not support modern NULL buffer usage */
 #define __MPLS_LIB_SUPPORT_REALPATH_WRAP__    (__MPLS_TARGET_OSVER < 1060)
 
-/* setattrlist */
+/* fsetattrlistat, fgetattrlistat */
 #define __MPLS_SDK_SUPPORT_FSETATTRLIST__     (__MPLS_SDK_MAJOR < 1060)
 #define __MPLS_LIB_SUPPORT_FSETATTRLIST__     (__MPLS_TARGET_OSVER < 1060)
 

--- a/include/unistd.h
+++ b/include/unistd.h
@@ -101,8 +101,10 @@
 
 #ifdef __LP64__
 int   fsetattrlist(int,void*,void*,size_t,unsigned int);
+int   fgetattrlist(int,void*,void*,size_t,unsigned int);
 #else /* defined (__LP64__) */
 int   fsetattrlist(int,void*,void*,size_t,unsigned long);
+int   fgetattrlist(int,void*,void*,size_t,unsigned long);
 #endif /* defined (__LP64__) */
 
 #endif  /* __MPLS_SDK_SUPPORT_FSETATTRLIST__ */

--- a/manual_tests/darwin_c.c
+++ b/manual_tests/darwin_c.c
@@ -212,6 +212,7 @@ int timespec_get = 0;
 #ifdef _SC_PHYS_PAGES
 #error _SC_PHYS_PAGES is unexpectedly defined
 #endif
+int fgetattrlist = 0;
 int fsetattrlist = 0;
 #endif /* __DARWIN_C_LEVEL < __DARWIN_C_FULL */
 

--- a/src/fgetattrlist.c
+++ b/src/fgetattrlist.c
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) 2024 Mihai Moldovan <ionic@ionic.de>, raf <raf@raf.org>
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
+/* MP support header */
+#include "MacportsLegacySupport.h"
+
+#if __MPLS_LIB_SUPPORT_FSETATTRLIST__
+
+#include <sys/attr.h>
+#include <sys/fcntl.h>
+#include <sys/param.h>
+#include <sys/errno.h>
+
+#include <fcntl.h>
+#include <string.h>
+#include <unistd.h>
+
+
+#ifdef __LP64__
+int fgetattrlist(int fd, void *a, void *buf, size_t size, unsigned int flags)
+#else /* defined (__LP64__) */
+int fgetattrlist(int fd, void *a, void *buf, size_t size, unsigned long flags)
+#endif /* defined (__LP64__) */
+{
+    int cont = 1,
+        ret = 0;
+
+    char fpath[MAXPATHLEN];
+    memset (fpath, 0, MAXPATHLEN);
+    if (-1 == fcntl(fd, F_GETPATH, fpath)) {
+        ret = EBADF;
+        cont = 0;
+    }
+
+#if __MPLS_TARGET_OSVER < 1080
+    /*
+     * Older systems don't correctly check if no attributes are to be read, which usually
+     * means a buffer size of zero and return an error since they malloc a block of
+     * memory with size zero, leading to ENOMEM.
+     *
+     * Emulate the fix from 10.8 for those.
+	 *
+	 * Note: This check is inherited from fsetattrlist() and might or might
+	 * not be appropriate here (but it seems reasonable).
+     */
+    const struct attrlist *al = a;
+    if (al->commonattr == 0 &&
+        (al->volattr & ~ATTR_VOL_INFO) == 0 &&
+        al->dirattr == 0 &&
+        al->fileattr == 0 &&
+        al->forkattr == 0) {
+        cont = 0;
+
+        /*
+         * Explicitly let the potential error from above pass through, since that's what
+         * the original function seems to do as well.
+         */
+    }
+#endif
+
+    if (cont) {
+        ret = getattrlist(fpath, a, buf, size, flags);
+    }
+
+    return ret;
+}
+
+#endif  /* __MPLS_LIB_SUPPORT_FSETATTRLIST__ */

--- a/test/test_fgetattrlist.c
+++ b/test/test_fgetattrlist.c
@@ -1,0 +1,68 @@
+/*
+ * Copyright (C) 2024 raf <raf@raf.org>
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
+/* Based on the first example in the getattrlist(2) manual entry */
+
+#include <assert.h>
+#include <stdlib.h>
+#include <stdio.h>
+#include <string.h>
+#include <fcntl.h>
+#include <unistd.h>
+#include <sys/attr.h>
+#include <sys/errno.h>
+#include <sys/vnode.h>
+
+typedef struct attrlist attrlist_t;
+
+struct FInfoAttrBuf {
+    u_int32_t       length;
+    fsobj_type_t    objType;
+    char            finderInfo[32];
+}  __attribute__((aligned(4), packed));
+typedef struct FInfoAttrBuf FInfoAttrBuf;
+
+static int FInfoDemo(int fd)
+{
+    int             err;
+    attrlist_t      attrList;
+    FInfoAttrBuf    attrBuf;
+
+    memset(&attrList, 0, sizeof(attrList));
+    attrList.bitmapcount = ATTR_BIT_MAP_COUNT;
+    attrList.commonattr  = ATTR_CMN_OBJTYPE | ATTR_CMN_FNDRINFO;
+
+    err = fgetattrlist(fd, &attrList, &attrBuf, sizeof(attrBuf), 0);
+    if (err != 0)
+        err = errno;
+
+    if (err == 0)
+        assert(attrBuf.length == sizeof(attrBuf));
+
+    return err;
+}
+
+/* Note: Not an exhaustive test. Just call fgetattrlist(). */
+
+int main(int ac, char **av)
+{
+    int rc = (FInfoDemo(open(".", O_RDONLY)) == 0) ? EXIT_SUCCESS : EXIT_FAILURE;
+    if (rc != EXIT_SUCCESS)
+        printf("fgetattrlist() failed, possibly correctly due to an unexpected filesystem type\n");
+    return rc;
+}
+
+/* vi:set et ts=4 sw=4: */

--- a/test/test_fsetattrlist.c
+++ b/test/test_fsetattrlist.c
@@ -1,0 +1,95 @@
+/*
+ * Copyright (C) 2024 raf <raf@raf.org>
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
+/* Based on the first example in the getattrlist(2) manual entry */
+
+#include <assert.h>
+#include <stdlib.h>
+#include <stdio.h>
+#include <stddef.h>
+#include <string.h>
+#include <fcntl.h>
+#include <sys/attr.h>
+#include <sys/errno.h>
+#include <unistd.h>
+#include <sys/vnode.h>
+
+typedef struct attrlist attrlist_t;
+
+struct FInfoAttrBuf
+{
+    u_int32_t    length;
+    fsobj_type_t objType;
+    char         finderInfo[32];
+};
+typedef struct FInfoAttrBuf FInfoAttrBuf;
+
+static int FInfoDemo(int fd, const char *type, const char *creator)
+{
+    int          err;
+    attrlist_t   attrList;
+    FInfoAttrBuf attrBuf;
+
+    assert(strlen(type) == 4);
+    assert(strlen(creator) == 4);
+
+    memset(&attrList, 0, sizeof(attrList));
+    attrList.bitmapcount = ATTR_BIT_MAP_COUNT;
+    attrList.commonattr  = ATTR_CMN_OBJTYPE | ATTR_CMN_FNDRINFO;
+
+    err = fgetattrlist(fd, &attrList, &attrBuf, sizeof(attrBuf), 0);
+    if (err != 0)
+    {
+        err = errno;
+    }
+
+    if ((err == 0) && (attrBuf.objType != VREG))
+    {
+        fprintf(stderr, "Not a standard file.");
+        err = EINVAL;
+    }
+    else
+    {
+        memcpy(&attrBuf.finderInfo[0], type,    4);
+        memcpy(&attrBuf.finderInfo[4], creator, 4);
+
+        attrList.commonattr = ATTR_CMN_FNDRINFO;
+        err = fsetattrlist(
+            fd,
+            &attrList,
+            attrBuf.finderInfo,
+            sizeof(attrBuf.finderInfo),
+            0
+        );
+    }
+
+    return err;
+}
+
+/* Note: Not an exhaustive test. Just call fsetattrlist(). */
+
+int main(int ac, char **av)
+{
+    const char *fname = "./.jnk.tmp";
+    int fd = open(fname, O_CREAT | O_RDWR, S_IRWXU);
+    int rc = (FInfoDemo(fd, "TYPE", "CRTR") == 0) ? EXIT_SUCCESS : EXIT_FAILURE;
+    unlink(fname);
+    if (rc != EXIT_SUCCESS)
+        printf("fgetattrlist() failed, possibly correctly due to an unexpected filesystem type\n");
+    return rc;
+}
+
+/* vi:set et ts=4 sw=4: */


### PR DESCRIPTION
This adds an implementation of `fgetattrlist()`. Tested on 10.14.6, 10.6.8, and 10.4.11 (ppc) but only the 10.4 test means anything. The test is very basic. It just calls the function on the current directory's file descriptor, and only requires that it doesn't return an error.

I noticed a strange thing when testing on 10.4 (ppc). The first time I run:

    PATH=/opt/local/bin:$PATH CC=gcc-apple-4.2 CFLAGS=-isystem`pwd`/tiger_only/include make test

I get an error:

    ld: file not found: src/fdopendir.dl.o.inode32.ppc

But if I run it again, it works. This happens with or without this change. I suspect that it doesn't matter.