### PR TITLE
Add vdprintf(), Fix dprintf()

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ Wrapped headers and replaced functions are:
   </tr>
   <tr>
     <td><code>stdio.h</code></td>
-    <td>Adds <code>dprintf</code>, <code>getline</code>, <code>getdelim</code>,
+    <td>Adds <code>dprintf</code>, <code>vdprintf</code>, <code>getline</code>, <code>getdelim</code>,
         <code>open_memstream</code>, and <code>fmemopen</code> functions</td>
     <td>OSX10.6, OSX10.12 (open_memstream)</td>
   </tr>

--- a/include/MacportsLegacySupport.h
+++ b/include/MacportsLegacySupport.h
@@ -173,7 +173,7 @@
 #define __MPLS_SDK_SUPPORT_STRNDUP__          (__MPLS_SDK_MAJOR < 1070)
 #define __MPLS_LIB_SUPPORT_STRNDUP__          (__MPLS_TARGET_OSVER < 1070)
 
-/* dprintf */
+/* dprintf, vdprintf */
 #define __MPLS_SDK_SUPPORT_DPRINTF__          (__MPLS_SDK_MAJOR < 1070)
 #define __MPLS_LIB_SUPPORT_DPRINTF__          (__MPLS_TARGET_OSVER < 1070)
 

--- a/include/stdio.h
+++ b/include/stdio.h
@@ -37,6 +37,7 @@
 
 __MP__BEGIN_DECLS
 extern int dprintf(int fd, const char * __restrict format, ...);
+extern int vdprintf(int fd, const char * __restrict format, va_list ap);
 __MP__END_DECLS
 
 #endif /* __MPLS_SDK_SUPPORT_DPRINTF__ */

--- a/manual_tests/darwin_c.c
+++ b/manual_tests/darwin_c.c
@@ -57,6 +57,7 @@ int fdopendir = 0;
 #include <stdio.h>
 #if __DARWIN_C_LEVEL < 200809L
 int dprintf = 0;
+int vdprintf = 0;
 int getdelim = 0;
 int getline = 0;
 int open_memstream = 0;

--- a/src/dprintf.c
+++ b/src/dprintf.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Evan Miller   <emmiller@gmail.com>
+ * Copyright (c) 2021 Evan Miller <emmiller@gmail.com>, 2024 raf <raf@raf.org>
  *
  * Permission to use, copy, modify, and distribute this software for any
  * purpose with or without fee is hereby granted, provided that the above
@@ -23,7 +23,8 @@
 #include <sys/errno.h>
 
 int dprintf(int fildes, const char * __restrict format, ...) {
-    FILE *stream = fdopen(fildes, "w");
+    int dup_fildes = dup(fildes);
+    FILE *stream = fdopen(dup_fildes, "w");
     if (stream == NULL) {
         errno = EBADF;
         return -1;
@@ -32,6 +33,21 @@ int dprintf(int fildes, const char * __restrict format, ...) {
     va_start(ap, format);
     int result = vfprintf(stream, format, ap);
     va_end(ap);
+    fclose(stream);
+    return result;
+}
+
+int vdprintf(int fildes, const char * __restrict format, va_list ap) {
+    int dup_fildes = dup(fildes);
+    FILE *stream = fdopen(dup_fildes, "w");
+    if (stream == NULL) {
+        errno = EBADF;
+        return -1;
+    }
+    va_list ap_copy;
+    va_copy(ap_copy, ap);
+    int result = vfprintf(stream, format, ap_copy);
+    va_end(ap_copy);
     fclose(stream);
     return result;
 }

--- a/test/test_dprintf.c
+++ b/test/test_dprintf.c
@@ -1,7 +1,18 @@
 
 #include <stdio.h>
+#include <stdarg.h>
+
+int test_vdprintf(int fd, const char *format, ...)
+{
+	va_list args;
+	va_start(args, format);
+	int ret = vdprintf(fd, format, args);
+	va_end(args);
+	return ret;
+}
 
 int main() {
     dprintf(fileno(stdout), "Hello, %s! My favorite number is %d\n", "Joe", 42);
+    test_vdprintf(fileno(stdout), "Hello, %s! My favorite number is %d\n", "Joe", 42);
     return 0;
 }


### PR DESCRIPTION
The `dprintf()` function has a big bug. It closes the file descriptor that is passed to it. So it only works once. After that, there is no output on that file descriptor. This is because it calls `fdopen()` and `fclose()` but it doesn't first call `dup()`. This pull request fixes that, and adds the corresponding `vdprintf()` function as well (tested on 10.6 and 10.4).