### PR TITLE
Multiple changes (primarily cleanups) - see individual commits

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -176,6 +176,12 @@ FDOPENDIRRUNS   := $(patsubst \
 STATXXSRCS_C    := $(wildcard $(TESTNAMEPREFIX)stat*.c)
 STATXXRUNS      := $(patsubst \
                      $(TESTNAMEPREFIX)%.c,$(TESTRUNPREFIX)%,$(STATXXSRCS_C))
+STPNCHKSRCS_C    := $(wildcard $(TESTNAMEPREFIX)stpncpy_chk*.c)
+STPNCHKRUNS      := $(patsubst \
+                     $(TESTNAMEPREFIX)%.c,$(TESTRUNPREFIX)%,$(STPNCHKSRCS_C))
+STRNCHKSRCS_C    := $(wildcard $(TESTNAMEPREFIX)strncpy_chk*.c)
+STRNCHKRUNS      := $(patsubst \
+                     $(TESTNAMEPREFIX)%.c,$(TESTRUNPREFIX)%,$(STRNCHKSRCS_C))
 
 # Tests that are only run manually
 MANTESTDIR       = manual_tests
@@ -393,6 +399,12 @@ $(TESTRUNPREFIX)fdopendir_all: $(FDOPENDIRRUNS)
 
 # Provide a target for all "stat" tests
 $(TESTRUNPREFIX)stat_all: $(STATXXRUNS)
+
+# Provide a target for all "stpncpy_chk" tests
+$(TESTRUNPREFIX)stpncpy_chk_all: $(STPNCHKRUNS)
+
+# Provide a target for all "strncpy_chk" tests
+$(TESTRUNPREFIX)strncpy_chk_all: $(STRNCHKRUNS)
 
 $(MANTESTRUNS): $(MANRUNPREFIX)%: $(MANTESTPREFIX)%
 	$< $(TEST_ARGS)

--- a/include/MacportsLegacySupport.h
+++ b/include/MacportsLegacySupport.h
@@ -154,13 +154,9 @@
 #define __MPLS_SDK_SUPPORT_TIMESPEC_GET__     (__MPLS_SDK_MAJOR < 101500)
 #define __MPLS_LIB_SUPPORT_TIMESPEC_GET__     (__MPLS_TARGET_OSVER < 101500)
 
-/* "at" calls */
+/* "at" calls, including fdopendir */
 #define __MPLS_SDK_SUPPORT_ATCALLS__          (__MPLS_SDK_MAJOR < 101000)
 #define __MPLS_LIB_SUPPORT_ATCALLS__          (__MPLS_TARGET_OSVER < 101000)
-
-/* fdopendir */
-#define __MPLS_SDK_SUPPORT_FDOPENDIR__        (__MPLS_SDK_MAJOR < 101000)
-#define __MPLS_LIB_SUPPORT_FDOPENDIR__        (__MPLS_TARGET_OSVER < 101000)
 
 /* new signature for scandir and alphasort */
 #define __MPLS_SDK_SUPPORT_NEW_SCANDIR__      (__MPLS_SDK_MAJOR < 1080)
@@ -326,8 +322,7 @@
 #define __MPLS_LIB_SUPPORT_STAT64__      (__MPLS_TARGET_OSVER < 1050)
 
 /* Compound macros, bundling functionality needed by multiple single features. */
-#define __MPLS_LIB_NEED_BEST_FCHDIR__    (__MPLS_LIB_SUPPORT_FDOPENDIR__ \
-                                          || __MPLS_LIB_SUPPORT_ATCALLS__ \
+#define __MPLS_LIB_NEED_BEST_FCHDIR__    (__MPLS_LIB_SUPPORT_ATCALLS__ \
                                           || __MPLS_LIB_SUPPORT_SETATTRLISTAT__)
 
 #define __MPLS_LIB_SUPPORT_REALPATH_WRAP__ (__MPLS_LIB_SUPPORT_REALPATH_ALLOC__ \

--- a/include/MacportsLegacySupport.h
+++ b/include/MacportsLegacySupport.h
@@ -326,12 +326,6 @@
 #define __MPLS_LIB_SUPPORT_STAT64__      (__MPLS_TARGET_OSVER < 1050)
 
 /* Compound macros, bundling functionality needed by multiple single features. */
-#define __MPLS_SDK_NEED_ATCALL_MACROS__  (__MPLS_SDK_SUPPORT_ATCALLS__ \
-                                          || __MPLS_SDK_SUPPORT_SETATTRLISTAT__)
-
-#define __MPLS_SDK_NEED_BEST_FCHDIR__    (__MPLS_SDK_SUPPORT_FDOPENDIR__ \
-                                          || __MPLS_SDK_SUPPORT_ATCALLS__ \
-                                          || __MPLS_SDK_SUPPORT_SETATTRLISTAT__)
 #define __MPLS_LIB_NEED_BEST_FCHDIR__    (__MPLS_LIB_SUPPORT_FDOPENDIR__ \
                                           || __MPLS_LIB_SUPPORT_ATCALLS__ \
                                           || __MPLS_LIB_SUPPORT_SETATTRLISTAT__)

--- a/include/dirent.h
+++ b/include/dirent.h
@@ -32,7 +32,7 @@
 #if __DARWIN_C_LEVEL >= 200809L
 
 /* fdopendir */
-#if __MPLS_SDK_SUPPORT_FDOPENDIR__
+#if __MPLS_SDK_SUPPORT_ATCALLS__
 
 __MP__BEGIN_DECLS
 
@@ -44,7 +44,7 @@ extern DIR *fdopendir(int fd) __DARWIN_ALIAS_I(fdopendir);
 
 __MP__END_DECLS
 
-#endif /* __MPLS_SDK_SUPPORT_FDOPENDIR__ */
+#endif /* __MPLS_SDK_SUPPORT_ATCALLS__ */
 
 /* new signature for scandir and alphasort (optionally) */
 #if __MPLS_SDK_SUPPORT_NEW_SCANDIR__

--- a/manual_tests/cdefsinfo.c
+++ b/manual_tests/cdefsinfo.c
@@ -30,6 +30,49 @@ int printf(const char *format, ...);
 #define PRINT_UNDEF(x) printf(#x " is undefined\n")
 
 static void
+print_compiler(void)
+{
+  #ifdef __cplusplus
+  PRINT_VAR(__cplusplus);
+  #else
+  PRINT_UNDEF(__cplusplus);
+  #endif
+
+  #ifdef __GNUC__
+  PRINT_VAR(__GNUC__);
+  #else
+  PRINT_UNDEF(__GNUC__);
+  #endif
+  #ifdef __GNUC_MINOR__
+  PRINT_VAR(__GNUC_MINOR__);
+  #else
+  PRINT_UNDEF(__GNUC_MINOR__);
+  #endif
+
+  #ifdef __clang_major__
+  PRINT_VAR(__clang_major__);
+  #else
+  PRINT_UNDEF(__clang_major__);
+  #endif
+  #ifdef __clang_minor__
+  PRINT_VAR(__clang_minor__);
+  #else
+  PRINT_UNDEF(__clang_minor__);
+  #endif
+
+  #ifdef __APPLE_CC__
+  PRINT_VAR(__APPLE_CC__);
+  #else
+  PRINT_UNDEF(__APPLE_CC__);
+  #endif
+  #ifdef __apple_build_version__
+  PRINT_VAR(__apple_build_version__);
+  #else
+  PRINT_UNDEF(__apple_build_version__);
+  #endif
+}
+
+static void
 print_before_cdefs(void)
 {
   printf("  Before <sys/cdefs.h>:\n");
@@ -246,6 +289,8 @@ main(int argc, char *argv[])
 {
   (void) argc; (void) argv;
 
+  printf("\n");
+  print_compiler();
   printf("\n");
   PRINT_VAR(__MPLS_SDK_MAJOR);
   printf("\n");

--- a/src/atcalls.c
+++ b/src/atcalls.c
@@ -36,35 +36,33 @@
 #include "MacportsLegacySupport.h"
 #if __MPLS_LIB_SUPPORT_ATCALLS__
 
-#include "common-priv.h"
-
-#include <sys/attr.h>
-#include <sys/errno.h>
-#include <sys/fcntl.h>
-#include <sys/param.h>
-#include <sys/stat.h>
-#include <sys/mount.h>
-#include <sys/ucred.h>
-#include <sys/shm.h>
-#include <sys/stdio.h>  /* For renameat() */
-#include <sys/unistd.h>
-
 #include <assert.h>
+#include <dirent.h>
 #include <dlfcn.h>
 #include <stdarg.h>
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include <unistd.h>
-#include <dirent.h>
 #include <string.h>
+#include <unistd.h>
 
+#include <sys/attr.h>
+#include <sys/errno.h>
+#include <sys/fcntl.h>
+#include <sys/mount.h>
+#include <sys/param.h>
+#include <sys/shm.h>
+#include <sys/stdio.h>  /* For renameat() */
+#include <sys/stat.h>
+#include <sys/ucred.h>
+#include <sys/unistd.h>
 
 /* this is some apple internal magic */
-#include <sys/syscall.h>
 #include <fcntl.h>
+#include <sys/syscall.h>
 
+#include "atcalls.h"
 
 // buf is a pointer to a buffer of PATH_MAX or larger size
 static int

--- a/src/atcalls.h
+++ b/src/atcalls.h
@@ -25,14 +25,14 @@
 
  /*
   * NOTICE: This chunk of header was refactored from the above Apple-supplied
-  * file, atcalls.c. The relevant part of that header was moved here.
-  * for use as a supporting file for MacPorts legacy support library. This notice
+  * file, atcalls.c.  The relevant part of that header was moved here for use
+  * as a supporting file for MacPorts legacy support library. This notice
   * is included in support of clause 2.2 (b) of the Apple Public License,
   * Version 2.0.
   */
 
-#ifndef _MACPORTS_COMMON_PRIV_H_
-#define _MACPORTS_COMMON_PRIV_H_
+#ifndef _MACPORTS_ATCALLS_H_
+#define _MACPORTS_ATCALLS_H_
 
 #include <fcntl.h>
 #include <unistd.h>
@@ -69,4 +69,4 @@ int best_fchdir(int dirfd);
 
 #define ATCALL(fd, p, what)  _ATCALL(fd, p, -1, what)
 
-#endif /* _MACPORTS_COMMON_PRIV_H_ */
+#endif /* _MACPORTS_ATCALLS_H_ */

--- a/src/best_fchdir.c
+++ b/src/best_fchdir.c
@@ -21,10 +21,13 @@
 
 #if __MPLS_LIB_NEED_BEST_FCHDIR__
 
-#include "common-priv.h"
-
 #include <unistd.h>
+
 #include <sys/syscall.h>
+
+#ifndef SYS___pthread_fchdir
+#define SYS___pthread_fchdir 349
+#endif
 
 int best_fchdir(int dirfd)
 {

--- a/src/common-priv.h
+++ b/src/common-priv.h
@@ -34,20 +34,11 @@
 #ifndef _MACPORTS_COMMON_PRIV_H_
 #define _MACPORTS_COMMON_PRIV_H_
 
-/* MP support header */
-#include "MacportsLegacySupport.h"
-/* Should be generic enough so that we don't need a global feature macro. */
-
-/* Do our SDK-related setup */
-#include <_macports_extras/sdkversion.h>
-
-#include <sys/errno.h>
-
-#if __MPLS_SDK_NEED_ATCALL_MACROS__
-#include <sys/fcntl.h>
 #include <fcntl.h>
 #include <unistd.h>
-#endif /* __MPLS_SDK_NEED_ATCALL_MACROS__ */
+
+#include <sys/errno.h>
+#include <sys/fcntl.h>
 
 #define PROTECT_ERRNO(what)  ({ int __err = (errno); what; errno = __err; })
 #define ERR_ON(code, what)   if (what) { errno = (code); return -1; }
@@ -56,15 +47,7 @@
 # define SYS___pthread_fchdir 349
 #endif
 
-
-#if __MPLS_SDK_NEED_BEST_FCHDIR__
-
 int best_fchdir(int dirfd);
-
-#endif /* __MPLS_SDK_NEED_BEST_FCHDIR__ */
-
-
-#if __MPLS_SDK_NEED_ATCALL_MACROS__
 
 #define _ATCALL(fd, p, onerr, what)                             \
     ({  typeof(what) __result;                                  \
@@ -89,7 +72,5 @@ int best_fchdir(int dirfd);
     })
 
 #define ATCALL(fd, p, what)  _ATCALL(fd, p, -1, what)
-
-#endif /* __MPLS_SDK_NEED_ATCALL_MACROS__ */
 
 #endif /* _MACPORTS_COMMON_PRIV_H_ */

--- a/src/common-priv.h
+++ b/src/common-priv.h
@@ -43,10 +43,6 @@
 #define PROTECT_ERRNO(what)  ({ int __err = (errno); what; errno = __err; })
 #define ERR_ON(code, what)   if (what) { errno = (code); return -1; }
 
-#ifndef SYS___pthread_fchdir
-# define SYS___pthread_fchdir 349
-#endif
-
 int best_fchdir(int dirfd);
 
 #define _ATCALL(fd, p, onerr, what)                             \

--- a/src/dirfuncs_compat.c
+++ b/src/dirfuncs_compat.c
@@ -34,7 +34,7 @@
 
 /* MP support header */
 #include "MacportsLegacySupport.h"
-#if __MPLS_LIB_SUPPORT_FDOPENDIR__
+#if __MPLS_LIB_SUPPORT_ATCALLS__
 
 #include "dirfuncs_compat.h"
 
@@ -78,4 +78,4 @@ __mpls_dirfd(DIR *dirp) {
     return dirfd(dirp);
 }
 
-#endif /* __MPLS_LIB_SUPPORT_FDOPENDIR__ */
+#endif /* __MPLS_LIB_SUPPORT_ATCALLS__ */

--- a/src/fdopendir.c
+++ b/src/fdopendir.c
@@ -28,7 +28,7 @@
  * https://linux.die.net/man/3/fdopendir
  */
 
-#if __MPLS_LIB_SUPPORT_FDOPENDIR__
+#if __MPLS_LIB_SUPPORT_ATCALLS__
 
 /*
  * Set up to use ino32 variants where possible.  This results in generating
@@ -223,4 +223,4 @@ fdopendir##isfx##usfx(int fd) \
 ALL_VARIANTS
 #undef VARIANT_ENT
 
-#endif /* __MPLS_LIB_SUPPORT_FDOPENDIR__ */
+#endif /* __MPLS_LIB_SUPPORT_ATCALLS__ */

--- a/src/fdopendir.c
+++ b/src/fdopendir.c
@@ -58,7 +58,7 @@
 
 #include <sys/stat.h>
 
-#include "common-priv.h"
+#include "atcalls.h"
 
 #if __MPLS_SDK_MAJOR < 1050
 #define __dd_fd dd_fd

--- a/src/setattrlistat.c
+++ b/src/setattrlistat.c
@@ -35,11 +35,12 @@
 
 #if __MPLS_LIB_SUPPORT_SETATTRLISTAT__
 
-#include "common-priv.h"
-
-#include <sys/attr.h>
 #include <assert.h>
 #include <stdint.h>
+
+#include <sys/attr.h>
+
+#include "atcalls.h"
 
 
 int setattrlistat(int dirfd, const char *pathname, void *a,

--- a/src/statxx.c
+++ b/src/statxx.c
@@ -146,7 +146,7 @@ fstat64(int fildes, struct stat64 *buf)
 int stat$INODE64(const char *__restrict path, struct stat64 *buf);
 int lstat$INODE64(const char *__restrict path, struct stat64 *buf);
 
-#include "common-priv.h"
+#include "atcalls.h"
 
 int fstatat(int fd, const char *__restrict path, struct stat *buf, int flag)
 {

--- a/test/test_dirfuncs_compat.c
+++ b/test/test_dirfuncs_compat.c
@@ -26,7 +26,7 @@
 
 /* MP support header */
 #include "MacportsLegacySupport.h"
-#if __MPLS_LIB_SUPPORT_FDOPENDIR__
+#if __MPLS_LIB_SUPPORT_ATCALLS__
 
 #include "../src/dirfuncs_compat.h"
 
@@ -42,8 +42,8 @@
 
 #include "test_fdopendir.c"
 
-#else /* !__MPLS_LIB_SUPPORT_FDOPENDIR__ */
+#else /* !__MPLS_LIB_SUPPORT_ATCALLS__ */
 
 int main(){ return 0; }
 
-#endif /* !__MPLS_LIB_SUPPORT_FDOPENDIR__ */
+#endif /* !__MPLS_LIB_SUPPORT_ATCALLS__ */

--- a/test/test_stpncpy_chk.c
+++ b/test/test_stpncpy_chk.c
@@ -99,6 +99,16 @@ print_after(void)
 #include <unistd.h>
 #include <sys/wait.h>
 
+/* Try to disable warnings for things we're intentionally provoking */
+#if defined(__clang__)
+  #pragma clang diagnostic ignored "-Wunknown-pragmas"
+  #pragma clang diagnostic ignored "-Wbuiltin-memcpy-chk-size"
+#elif defined(__GNUC__)
+  #pragma GCC diagnostic ignored "-Wpragmas"
+  #pragma GCC diagnostic ignored "-Wstringop-overflow"
+  #pragma GCC diagnostic ignored "-Warray-bounds"
+#endif
+
 const char *test_str = "The Quick Brown Fox";
 
 #define BUF_LEN 128  /* Generously longer than test_str */

--- a/test/test_strncpy_chk.c
+++ b/test/test_strncpy_chk.c
@@ -103,6 +103,18 @@ print_after(void)
 #include <unistd.h>
 #include <sys/wait.h>
 
+/* Try to disable warnings for things we're intentionally provoking */
+#if defined(__clang__)
+  #pragma clang diagnostic ignored "-Wunknown-pragmas"
+  #pragma clang diagnostic ignored "-Wbuiltin-memcpy-chk-size"
+  #pragma clang diagnostic ignored "-Wunknown-warning-option"
+  #pragma clang diagnostic ignored "-Wfortify-source"
+#elif defined(__GNUC__)
+  #pragma GCC diagnostic ignored "-Wpragmas"
+  #pragma GCC diagnostic ignored "-Wstringop-overflow"
+  #pragma GCC diagnostic ignored "-Warray-bounds"
+#endif
+
 const char *test_str = "The Quick Brown Fox";
 
 #define BUF_LEN 128  /* Generously longer than test_str */

--- a/xtest/test_scandir.c
+++ b/xtest/test_scandir.c
@@ -37,6 +37,12 @@
 #include <libgen.h>
 #include <stddef.h>
 #include <stdio.h>
+/* Check the new public definition. */
+#ifndef _MACPORTS_LEGACY_OLD_SCANDIR
+#warning _MACPORTS_LEGACY_OLD_SCANDIR is undefined
+#elif _MACPORTS_LEGACY_OLD_SCANDIR != (__MPLS_SDK_MAJOR < 1080)
+#warning _MACPORTS_LEGACY_OLD_SCANDIR is incorrect
+#endif
 
 /* Determine whether the old or new type of the 'compar' func is in effect. */
 #if !_MACPORTS_LEGACY_COMPATIBLE_SCANDIR && __MPLS_SDK_MAJOR < 1080
@@ -75,6 +81,8 @@ test_scandir(void)
   struct dirent **names;
   if (scandir(".", &names, NULL, alphasort)) return -1;
   if (scandir(".", &names, NULL, mysort)) return -1;
+  /* Also check our functions, which are now unconditionally available. */
+  if (__mpls_scandir(".", &names, NULL, __mpls_alphasort)) return -1;
   return 0;
 }
 


### PR DESCRIPTION
Notably:

- Adds support for code that can't tolerate the normal `scandir()` fix.
- Limits unavoidable GCC warnings to cases that really need the fix.

Tested (both from repo and from temp Portfile) on:
```
Mac OS X 10.4.11 8S165, PPC, Xcode 2.5 8M2558
Mac OS X 10.4.11 8S2167, i386, Xcode 2.5 8M2558
Mac OS X 10.4.11 8S2167, x86_64, Xcode 2.5 8M2558
Mac OS X 10.5.8 9L31a, PPC, Xcode 3.1.4 9M2809
Mac OS X 10.5.8 9L31a, i386, Xcode 3.1.4 9M2809
Mac OS X 10.5.8 9L31a, x86_64, Xcode 3.1.4 9M2809
Mac OS X 10.5.8 9L31a, PPC (i386 Rosetta), Xcode 3.1.4 9M2809
Mac OS X 10.6.8 10K549, i386, Xcode 3.2.6 10M2518
Mac OS X 10.6.8 10K549, x86_64, Xcode 3.2.6 10M2518
Mac OS X 10.6.8 10K549, PPC (i386 Rosetta), Xcode 3.2.6 10M2518
Mac OS X 10.7.5 11G63, x86_64, Xcode 4.6.3 4H1503
OS X 10.8.5 12F2560, x86_64, Xcode 5.1.1 5B1008
OS X 10.9.5 13F1911, x86_64, Xcode 6.2 6C131e
OS X 10.10.5 14F2511, x86_64, Xcode 7.2 7C68
OS X 10.11.6 15G22010, x86_64, Xcode 8.1 8B62
macOS 10.12.6 16G2136, x86_64, Xcode 9.2 9C40b
macOS 10.13.6 17G14042, x86_64, Xcode 10.1 10B61
macOS 10.14.6 18G9323, x86_64, Xcode 11.3.1 11C505
macOS 10.15.7 19H15, x86_64, Xcode 12.4 12D4e
macOS 11.7.10 20G1427, x86_64, Xcode 13.2.1 13C100
macOS 11.7.10 20G1427, arm64, Xcode 13.2.1 13C100
macOS 12.7.6 21H1320, x86_64, Xcode 14.2 14C18
macOS 12.7.6 21H1320, arm64, Xcode 14.2 14C18
macOS 13.7.1 22H221, arm64, Xcode 15.2 15C500b
macOS 14.7.1 23H222, arm64, Xcode 16.1 16B40
macOS 15.1.1 24B91, arm64, Xcode 16.1 16B40
```
