### PR TITLE
Add CPU_TYPE_ARM; update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Wrapped headers and replaced functions are:
   </tr>
   <tr>
     <td><code>copyfile.h</code></td>
-    <td>Wraps <code>copyfile_state_get</code> to support <code>COPYFILE_STATE_COPIED</code></td>
+    <td>Completely redone to provide 10.6 version</td>
     <td>OSX10.5</td>
   </tr>
   <tr>
@@ -60,7 +60,7 @@ Wrapped headers and replaced functions are:
     <td>OSX10.5</td>
   </tr>
   <tr>
-    <td rowspan="2"><code>pthread.h</code></td>
+    <td rowspan="3"><code>pthread.h</code></td>
     <td>Adds <code>PTHREAD_RWLOCK_INITIALIZER</code></td>
     <td>OSX10.4</td>
   </tr>
@@ -69,10 +69,18 @@ Wrapped headers and replaced functions are:
     <td>OSX10.5</td>
   </tr>
   <tr>
-    <td><code>stdio.h</code></td>
+    <td>Adds <code>pthread_chdir_np</code> and <code>pthread_fchdir_np</code> functions</td>
+    <td>OSX10.11</td>
+  </tr>
+  <tr>
+    <td rowspan="2"><code>stdio.h</code></td>
     <td>Adds <code>dprintf</code>, <code>vdprintf</code>, <code>getline</code>, <code>getdelim</code>,
         <code>open_memstream</code>, and <code>fmemopen</code> functions</td>
     <td>OSX10.6, OSX10.12 (open_memstream)</td>
+  </tr>
+  <tr>
+    <td>Adds include of <code>sys/stdio.h</code.</td>
+    <td>OSX10.9</td>
   </tr>
   <tr>
     <td rowspan="4"><code>stdlib.h</code></td>
@@ -102,9 +110,17 @@ Wrapped headers and replaced functions are:
     <td>OSX10.4(8)</td>
   </tr>
   <tr>
-    <td><code>time.h</code></td>
-    <td>Adds functions <code>clock_gettime</code>(macOS10.11) and <code>timespec_get</code>(macOS10.14). Defines <code>TIME_UTC</code> (macOS10.14). Declares <code>asctime_r</code>, <code>ctime_r</code>, <code>gmtime_r</code>, and <code>localtime_r</code> functions that are otherwise hidden in the presence of <code>_ANSI_SOURCE</code>, <code>_POSIX_C_SOURCE</code>, or <code>_XOPEN_SOURCE</code> (OSX10.4)</td>
-    <td>OSX10.4(11,14)</td>
+    <td rowspan="3"><code>time.h</code></td>
+    <td>Declares <code>asctime_r</code>, <code>ctime_r</code>, <code>gmtime_r</code>, and <code>localtime_r</code> functions that are otherwise hidden in the presence of <code>_ANSI_SOURCE</code>, <code>_POSIX_C_SOURCE</code>, or <code>_XOPEN_SOURCE</code></td>
+    <td>OSX10.4</td>
+  </tr>
+  <tr>
+    <td>Adds functions <code>clock_gettime</code>, clock_gettime_nsec_np</code> and <code>clock_settime</code></td>
+    <td>OSX10.11</td>
+  </tr>
+  <tr>
+    <td>Adds function <code>timespec_get</code></td>
+    <td>OSX10.14</td>
   </tr>
   <tr>
     <td><code>wchar.h</code></td>
@@ -122,6 +138,11 @@ Wrapped headers and replaced functions are:
     <td><code>net/if.h</code></td>
     <td>Adds include <code>sys/socket.h</code>, expected on current macOS systems</td>
     <td>OSX10.8</td>
+  </tr>
+  <tr>
+    <td><code>net/if_utun.h</code></td>
+    <td>Added when missing</td>
+    <td>OSX10.5</td>
   </tr>
   <tr>
     <td><code>xlocale/_wchar.h</code></td>
@@ -241,10 +262,8 @@ Wrapped headers and replaced functions are:
   </tr>
   <tr>
     <td><code>TargetConditionals.h</code></td>
-    <td>Adds definitions for <code>TARGET_CPU_ARM</code>, <code>TARGET_CPU_ARM64</code>,
-        <code>TARGET_OS_SIMULATOR</code>, <code>TARGET_OS_IOS</code>, <code>TARGET_OS_TV</code>,
-        <code>TARGET_OS_WATCH</code> and <code>TARGET_OS_OSX</code> if needed.</td>
-    <td>OSX10.10</td>
+    <td>Adds definitions for all TARGET_* definitions as listed in 15.x SDK, if needed.</td>
+    <td>???</td>
   </tr>
   <tr>
     <td><code>-</code></td>

--- a/include/mach/machine.h
+++ b/include/mach/machine.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022
+ * Copyright (c) 2025
  *
  * Permission to use, copy, modify, and distribute this software for any
  * purpose with or without fee is hereby granted, provided that the above
@@ -17,6 +17,10 @@
 /* Include the primary system mach/machine.h */
 #include_next <mach/machine.h>
 
+#ifndef CPU_TYPE_ARM
+#define CPU_TYPE_ARM            ((cpu_type_t) 12)
+#endif
+
 #ifndef CPU_SUBTYPE_ARM64E
-#define CPU_SUBTYPE_ARM64E              ((cpu_subtype_t) 2)
+#define CPU_SUBTYPE_ARM64E      ((cpu_subtype_t) 2)
 #endif

--- a/xtest/test_cputypes.c
+++ b/xtest/test_cputypes.c
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2025 Frederick H. G. Wright II <fw@fwright.net>
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
+/*
+ * This test is just a minimal test to verify the added CPU_* definitions
+ * in mach/machine.h.
+ */
+
+#include <libgen.h>
+#include <stdio.h>
+#include <string.h>
+
+#include <mach/machine.h>
+
+#define PRINT_VAR(x) if (verbose) printf("%s = %d\n", #x, x);
+#define PRINT_UNDEF(x) printf(#x " is undefined\n"); ret = 1;
+
+int
+main(int argc, char *argv[])
+{
+  int ret = 0, verbose = 0;
+
+  if (argc > 1 && !strcmp(argv[1], "-v")) verbose = 1;
+
+  #ifdef CPU_TYPE_ARM
+  PRINT_VAR(CPU_TYPE_ARM);
+  #else
+  PRINT_UNDEF(CPU_TYPE_ARM);
+  #endif
+
+  #ifdef CPU_SUBTYPE_ARM64E
+  PRINT_VAR(CPU_SUBTYPE_ARM64E);
+  #else
+  PRINT_UNDEF(CPU_SUBTYPE_ARM64E);
+  #endif
+
+  printf("%s %s.\n", basename(argv[0]), ret ? "failed" : "passed");
+  return ret;
+}


### PR DESCRIPTION
This is an additional change to fix https://trac.macports.org/ticket/71621, as well as previously neglected updates to README.md.

Tested new code (repo only) on
```
Mac OS X 10.4.11 8S165, PPC, Xcode 2.5 8M2558
Mac OS X 10.4.11 8S2167, i386, Xcode 2.5 8M2558
Mac OS X 10.4.11 8S2167, x86_64, Xcode 2.5 8M2558
Mac OS X 10.5.8 9L31a, i386, Xcode 3.1.4 9M2809
Mac OS X 10.5.8 9L31a, x86_64, Xcode 3.1.4 9M2809
Mac OS X 10.5.8 9L31a, PPC (i386 Rosetta), Xcode 3.1.4 9M2809
Mac OS X 10.6.8 10K549, i386, Xcode 3.2.6 10M2518
Mac OS X 10.6.8 10K549, x86_64, Xcode 3.2.6 10M2518
Mac OS X 10.6.8 10K549, PPC (i386 Rosetta), Xcode 3.2.6 10M2518
Mac OS X 10.7.5 11G63, x86_64, Xcode 4.6.3 4H1503
OS X 10.8.5 12F2560, x86_64, Xcode 5.1.1 5B1008
OS X 10.9.5 13F1911, x86_64, Xcode 6.2 6C131e
OS X 10.10.5 14F2511, x86_64, Xcode 7.2 7C68
OS X 10.11.6 15G22010, x86_64, Xcode 8.1 8B62
macOS 10.12.6 16G2136, x86_64, Xcode 9.2 9C40b
macOS 10.13.6 17G14042, x86_64, Xcode 10.1 10B61
macOS 10.14.6 18G9323, x86_64, Xcode 11.3.1 11C505
macOS 10.15.7 19H15, x86_64, Xcode 12.4 12D4e
macOS 11.7.10 20G1427, x86_64, Xcode 13.2.1 13C100
macOS 12.7.6 21H1320, x86_64, Xcode 14.2 14C18
macOS 13.7.2 22H313, arm64, Xcode 15.2 15C500b
macOS 14.7.2 23H311, arm64, Xcode 16.2 16C5032a
macOS 15.2 24C101, arm64, Xcode 16.2 16C5032a
```
