### PR TITLE
uninitialize mode in openat calls

### DIFF
--- a/src/atcalls.c
+++ b/src/atcalls.c
@@ -204,7 +204,7 @@ int mknodat(int dirfd, const char *pathname, mode_t mode, dev_t dev)
 
 int openat(int dirfd, const char *pathname, int flags, ...)
 {
-    mode_t mode = 0;
+    mode_t mode;
     if (flags & O_CREAT) {
         va_list ap;
         va_start(ap, flags);
@@ -217,7 +217,7 @@ int openat(int dirfd, const char *pathname, int flags, ...)
 
 int openat$NOCANCEL(int dirfd, const char *pathname, int flags, ...)
 {
-    mode_t mode = 0;
+    mode_t mode;
     if (flags & O_CREAT) {
         va_list ap;
         va_start(ap, flags);


### PR DESCRIPTION
AFAIK if `O_CREAT` isn't in flags, the mode argument is ignored.  Leaving the variable uninitialized saves the compiler from having to generate an instruction to initialize it to 0 when `O_CREAT` isn't specified.  This should save exactly 1 instruction on most architectures.  The micro-est of micro-optimizations, but still an objective improvement.