### PR TITLE
Multiple updates, mostly for clocks and clonefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -249,6 +249,10 @@ slibobjs: $(SLIBOBJS)
 
 allobjs: dlibobjs slibobjs syslibobjs
 
+# Rule to make assembler source for inspection (not used in normal builds)
+%.S: %.c
+	$(CC) -S -I$(SRCINCDIR) $(ALLCFLAGS) $< -o $@
+
 # Create a list of nonempty static object files.
 # Since completely empty archives are illegal, we use our dummy if there
 # would otherwise be no objects.

--- a/README.md
+++ b/README.md
@@ -171,6 +171,16 @@ Wrapped headers and replaced functions are:
     <td>OSX10.4</td>
   </tr>
   <tr>
+    <td><code>sys/attr.h</code></td>
+    <td>Adds missing <code>VOL_CAP_INT_CLONE</code> definition</td>
+    <td>OSX10.11</td>
+  </tr>
+  <tr>
+    <td><code>sys/clonefile.h</code></td>
+    <td>Adds <code>clonefile</code>, <code>clonefileat</code>, and <code>fclonefileat</code> functions</td>
+    <td>OSX10.11</td>
+  </tr>
+  <tr>
     <td rowspan="2"><code>sys/fcntl.h</code></td>
     <td>Adds missing <code>O_CLOEXEC</code>, <code>AT_FDCWD</code>, <code>AT_EACCESS</code>,
         <code>AT_SYMLINK_NOFOLLOW</code>, <code>AT_SYMLINK_FOLLOW</code>, and

--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@ approximately up to current expected standards.
 
 Three different libraries are provided
 
- - libMacportsLegacySupport.a      - A static library with the missing functions for the given OS.
- - libMacportsLegacySupport.dylib  - A dynamic library with the missing functions for the given OS.
+ - libMacportsLegacySupport.a      - A static library with the missing or enhanced functions for the given OS.
+ - libMacportsLegacySupport.dylib  - A dynamic library with the missing or enhanced functions for the given OS.
  - libMacportsLegacySystem.B.dylib - Similar to libMacportsLegacySupport.dylib but in addition re-exports the symbols from libSystem.B.dylib.
 
 To use this library within [MacPorts](https://github.com/macports)
@@ -115,7 +115,7 @@ Wrapped headers and replaced functions are:
     <td>OSX10.4</td>
   </tr>
   <tr>
-    <td>Adds functions <code>clock_gettime</code>, clock_gettime_nsec_np</code> and <code>clock_settime</code></td>
+    <td>Adds functions <code>clock_gettime</code>, <code>clock_gettime_nsec_np</code> and <code>clock_settime</code></td>
     <td>OSX10.11</td>
   </tr>
   <tr>
@@ -128,6 +128,15 @@ Wrapped headers and replaced functions are:
         <code>wcpncpy</code>, <code>wcscasecmp</code>, and <code>wcsncasecmp</code>
         functions</td>
     <td>OSX10.6</td>
+  </tr>
+  <tr>
+    <td rowspan="2"><code>mach/mach_time.h</code></td>
+    <td>Adds function <code>mach_approximate_time</code></td>
+    <td>OSX10.9</td>
+  </tr>
+  <tr>
+    <td>Adds functions <code>mach_continuous_time</code> and <code>mach_continuous_approximate_time</code></td>
+    <td>OSX10.11</td>
   </tr>
   <tr>
     <td><code>mach/machine.h</code></td>

--- a/README.md
+++ b/README.md
@@ -73,10 +73,13 @@ Wrapped headers and replaced functions are:
     <td>OSX10.11</td>
   </tr>
   <tr>
-    <td rowspan="2"><code>stdio.h</code></td>
-    <td>Adds <code>dprintf</code>, <code>vdprintf</code>, <code>getline</code>, <code>getdelim</code>,
-        <code>open_memstream</code>, and <code>fmemopen</code> functions</td>
-    <td>OSX10.6, OSX10.12 (open_memstream)</td>
+    <td rowspan="3"><code>stdio.h</code></td>
+    <td>Adds <code>dprintf</code>, <code>vdprintf</code>, <code>getline</code>, and <code>getdelim</code> functions</td>
+    <td>OSX10.6</td>
+  </tr>
+  <tr>
+    <td>Adds <code>open_memstream</code> and <code>fmemopen</code> functions</td>
+    <td>OSX10.12</td>
   </tr>
   <tr>
     <td>Adds include of <code>sys/stdio.h</code></td>
@@ -105,9 +108,13 @@ Wrapped headers and replaced functions are:
     <td>OSX10.6</td>
   </tr>
   <tr>
-    <td><code>strings.h</code></td>
-    <td>Adds <code>fls,flsl,ffsl</code>(OSX10.4) and <code>flsll,ffsll</code>(macOS10.8) functions</td>
-    <td>OSX10.4(8)</td>
+    <td rowspan="2"><code>strings.h</code></td>
+    <td>Adds <code>fls</code>, <code>flsl</code>, and <code>ffsl</code> functions</td>
+    <td>OSX10.4</td>
+  </tr>
+  <tr>
+    <td>Adds <code>flsll</code> and <code>ffsll</code> functions</td>
+    <td>OSX10.8</td>
   </tr>
   <tr>
     <td rowspan="3"><code>time.h</code></td>
@@ -176,7 +183,7 @@ Wrapped headers and replaced functions are:
   </tr>
   <tr>
     <td><code>sys/fsgetpath.h</code></td>
-    <td>Adds missing <code>utimensat</code>, <code>fsgetpath</code> and <code>setattrlistat</code> functions</td>
+    <td>Adds <code>fsgetpath</code> function</td>
     <td>OSX10.12</td>
   </tr>
   <tr>
@@ -198,15 +205,23 @@ Wrapped headers and replaced functions are:
     <td>OSX10.4</td>
   </tr>
   <tr>
-    <td><code>sys/stdio.h</code></td>
-    <td>Adds <code>renameat</code> function</td>
-    <td>OSX10.9</td>
+    <td><code>sys/random.h</code></td>
+    <td>Adds <code>getentropy</code> function</td>
+    <td>OSX10.11</td>
   </tr>
   <tr>
-    <td rowspan="3"><code>sys/stat.h</code></td>
+    <td><code>sys/socket.h</code></td>
+    <td>Corrects <code>CMSG_DATA</code> definition</td>
+    <td>OSX10.5</td>
+  </tr>
+  <tr>
+    <td rowspan="4"><code>sys/stat.h</code></td>
     <td>Adds <code>fchmodat</code>, <code>fstatat</code>,
         and <code>mkdirat</code> functions</td>
     <td>OSX10.9</td>
+  <tr>
+    <td>Adds <code>setattrlistat</code> and <code>utimensat</code> functions</td>
+    <td>OSX10.12</td>
   </tr>
   <tr>
     <td>Adds <code>lchmod</code> function</td>
@@ -217,14 +232,9 @@ Wrapped headers and replaced functions are:
     <td>OSX10.4</td>
   </tr>
   <tr>
-    <td><code>sys/random.h</code></td>
-    <td>Adds <code>getentropy</code> function</td>
-    <td>OSX10.11</td>
-  </tr>
-  <tr>
-    <td><code>sys/socket.h</code></td>
-    <td>Corrects <code>CMSG_DATA</code> definition</td>
-    <td>OSX10.5</td>
+    <td><code>sys/stdio.h</code></td>
+    <td>Adds <code>renameat</code> function</td>
+    <td>OSX10.9</td>
   </tr>
   <tr>
     <td><code>sys/time.h</code></td>

--- a/include/MacportsLegacySupport.h
+++ b/include/MacportsLegacySupport.h
@@ -397,4 +397,8 @@
                                                             || __MPLS_TARGET_OSVER == 1090 \
                                                             || __MPLS_TARGET_OSVER <  1060)
 
+/* clonefile, clonefileat, fclonefileat */
+#define __MPLS_SDK_SUPPORT_CLONEFILE__       (__MPLS_SDK_MAJOR < 101200)
+#define __MPLS_LIB_SUPPORT_CLONEFILE__       (__MPLS_TARGET_OSVER < 101200)
+
 #endif /* _MACPORTS_LEGACYSUPPORTDEFS_H_ */

--- a/include/sys/attr.h
+++ b/include/sys/attr.h
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2025 Frederick H. G. Wright II <fw@fwright.net>
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
+#ifndef _MACPORTS_SYS_ATTR_H_
+#define _MACPORTS_SYS_ATTR_H_
+
+/* Simple wrapper to add VOL_CAP_INT_CLONE (from 10.12+) */
+
+/* Include the primary system sys/attr.h */
+#include_next <sys/attr.h>
+
+#ifndef VOL_CAP_INT_CLONE
+#define VOL_CAP_INT_CLONE 0x00010000
+#endif
+
+#endif /* _MACPORTS_SYS_ATTR_H_ */

--- a/include/sys/clonefile.h
+++ b/include/sys/clonefile.h
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2025 Frederick H. G. Wright II <fw@fwright.net>
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
+#ifndef _MACPORTS_SYS_CLONEFILE_H_
+#define _MACPORTS_SYS_CLONEFILE_H_
+
+/*
+ * This is a wrapper/replacement header for sys/clonefile.h, handling its
+ * absence in the <10.12 SDKs.  In those cases, we provide substitute
+ * definitions; otherwise we just pass through the SDK header as is.
+ */
+
+/* Do our SDK-related setup */
+#include <_macports_extras/sdkversion.h>
+
+#if __MPLS_SDK_SUPPORT_CLONEFILE__
+
+/* Options for clonefile calls */
+#define CLONE_NOFOLLOW   0x0001     /* Don't follow symbolic links */
+
+#include <stdint.h>
+
+__MP__BEGIN_DECLS
+
+int clonefileat(int, const char *, int, const char *, uint32_t);
+int fclonefileat(int, int, const char *, uint32_t);
+int clonefile(const char *, const char *, uint32_t);
+
+__MP__END_DECLS
+
+#else  /* !__MPLS_SDK_SUPPORT_CLONEFILE__ */
+
+#include_next <sys/clonefile.h>
+
+#endif  /* !__MPLS_SDK_SUPPORT_CLONEFILE__ */
+
+#endif /* _MACPORTS_SYS_CLONEFILE_H_ */

--- a/src/clonefile.c
+++ b/src/clonefile.c
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2025 Frederick H. G. Wright II <fw@fwright.net>
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
+/* MP support header */
+#include "MacportsLegacySupport.h"
+
+#if __MPLS_LIB_SUPPORT_CLONEFILE__
+
+/*
+ * This provides degenerate implementations of *clonefile*() which always
+ * fail, since the real versions only work on APFS, and no OS version that
+ * uses this code supports APFS.
+ *
+ * At present, these functions always fail immediately with ENOTSUP, though
+ * real implementations might fail in other ways when given bad arguments.
+ */
+
+#include <errno.h>
+
+#include <sys/clonefile.h>
+#include <sys/fcntl.h>
+
+int
+clonefile(const char *src, const char *dst, uint32_t flags)
+{
+  return clonefileat(AT_FDCWD, src, AT_FDCWD, dst, flags);
+}
+
+int
+clonefileat(int src_dirfd, const char *src,
+            int dst_dirfd, const char *dst, uint32_t flags)
+{
+  (void) src_dirfd; (void) src; (void) dst_dirfd; (void) dst; (void) flags;
+
+  errno = ENOTSUP;
+  return -1;
+}
+
+int
+fclonefileat(int srcfd, int dst_dirfd, const char *dst, uint32_t flags)
+{
+  (void) srcfd; (void) dst_dirfd; (void) dst; (void) flags;
+
+  errno = ENOTSUP;
+  return -1;
+}
+
+#endif /* __MPLS_LIB_SUPPORT_CLONEFILE__ */

--- a/src/compiler.h
+++ b/src/compiler.h
@@ -19,7 +19,7 @@
 
 /* Macros for compiler-specific features */
 
-/* Branch prediction hints */
+/* Branch prediction hints, similar to Apple's os_fastpath/os_slowpath */
 #ifdef __has_builtin
   #if __has_builtin(__builtin_expect)
     #define MPLS_EXPECT(x, v) __builtin_expect((x), (v))

--- a/src/compiler.h
+++ b/src/compiler.h
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2025 Frederick H. G. Wright II <fw@fwright.net>
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
+#ifndef __MACPORTS_COMPILER_H
+#define __MACPORTS_COMPILER_H
+
+/* Macros for compiler-specific features */
+
+/* Branch prediction hints */
+#ifdef __has_builtin
+  #if __has_builtin(__builtin_expect)
+    #define MPLS_EXPECT(x, v) __builtin_expect((x), (v))
+    #define MPLS_FASTPATH(x) ((__typeof__(x))MPLS_EXPECT((long)(x), ~0l))
+    #define MPLS_SLOWPATH(x) ((__typeof__(x))MPLS_EXPECT((long)(x), 0l))
+  #endif
+#endif  /* __has_builtin */
+
+#ifndef MPLS_EXPECT
+  #define MPLS_EXPECT(x, v) (x)
+  #define MPLS_FASTPATH(x) (x)
+  #define MPLS_SLOWPATH(x) (x)
+#endif
+
+#endif /* __MACPORTS_COMPILER_H */

--- a/src/packet.c
+++ b/src/packet.c
@@ -101,6 +101,7 @@
 #include <sys/time.h>
 #include <sys/types.h>
 
+#include "compiler.h"
 #include "endian.h"
 
 #define CMSG_DATALEN(cmsg) ((uint8_t *) (cmsg) + (cmsg)->cmsg_len \
@@ -138,7 +139,7 @@ static recvmsg_fn_t *
 sys_recvmsg(fv_type_t fvtype)
 {
   /* Return cached value if available */
-  if (fv_adrs[fvtype]) return fv_adrs[fvtype];
+  if (MPLS_FASTPATH(fv_adrs[fvtype])) return fv_adrs[fvtype];
 
   /* Or cache and return address of desired variant if available */
   if ((fv_adrs[fvtype] = dlsym(RTLD_NEXT, fv_names[fvtype]))) {
@@ -395,7 +396,7 @@ recvmsg_internal(int socket, struct msghdr *message, int flags,
   ssize_t ret;
 
   /* Determine Rosettaness, if not already known */
-  if (!is_rosetta) is_rosetta = check_rosetta();
+  if (MPLS_SLOWPATH(!is_rosetta)) is_rosetta = check_rosetta();
 
   /* Just pass through if Rosetta-only and not Rosetta */
   if (!FORMAT_FIX && is_rosetta < 0) {

--- a/src/pthread_get_stacksize_np.c
+++ b/src/pthread_get_stacksize_np.c
@@ -8,6 +8,8 @@
 #include <dlfcn.h>
 #include <stdlib.h>
 
+#include "compiler.h"
+
 #if __MPLS_TARGET_OSVER >= 1090
 /* private system call available on OS X Mavericks (version 10.9) and later */
 /* see https://github.com/apple-oss-distributions/libpthread/blob/ba8e1488a0e6848b710c5daad2e226f66cfed656/private/pthread/private.h#L34 */
@@ -60,7 +62,7 @@ size_t pthread_get_stacksize_np(pthread_t t) {
     } else {
         /* bug only affects main thread */
         static size_t (*os_pthread_get_stacksize_np)(pthread_t);
-        if (!os_pthread_get_stacksize_np) {
+        if (MPLS_SLOWPATH(!os_pthread_get_stacksize_np)) {
             os_pthread_get_stacksize_np =
                 dlsym(RTLD_NEXT, "pthread_get_stacksize_np");
             /* Something's badly broken if this fails */

--- a/src/realpath.c
+++ b/src/realpath.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Frederick H. G. Wright II <fw@fwright.net>
+ * Copyright (c) 2025 Frederick H. G. Wright II <fw@fwright.net>
  *
  * Permission to use, copy, modify, and distribute this software for any
  * purpose with or without fee is hereby granted, provided that the above
@@ -32,6 +32,8 @@
 
 /* Now undo our macro kludge */
 #undef realpath
+
+#include "compiler.h"
 
 /*
  * This provides a wrapper for realpath() in order to make the 10.6+
@@ -118,7 +120,7 @@ realpath_internal(const char * __restrict file_name,
   int saved_errno;
 
   /* Locate proper OS realpath(), with fallback if needed */
-  if (!(os_realpath = rp_adr[version])) {
+  if (MPLS_SLOWPATH(!(os_realpath = rp_adr[version]))) {
     os_realpath = rp_adr[version] = dlsym(RTLD_NEXT, rp_name[version]);
     if (!os_realpath && version != rp_basic) {
       os_realpath = rp_adr[version] = dlsym(RTLD_NEXT, rp_name[rp_basic]);

--- a/src/sysconf.c
+++ b/src/sysconf.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019
+ * Copyright (c) 2025
  *
  * Permission to use, copy, modify, and distribute this software for any
  * purpose with or without fee is hereby granted, provided that the above
@@ -27,6 +27,8 @@
 #include <dlfcn.h>
 #include <stdlib.h>
 #include <stddef.h>
+
+#include "compiler.h"
 
 /*
  * Emulate several commonly used but missing (or broken) selectors from
@@ -97,7 +99,7 @@ long sysconf(int name) {
 #endif /* __MPLS_LIB_SUPPORT_SYSCONF_PHYS_PAGES__ */
 
     /* for any other values of "name", call the real sysconf() */
-    if (!os_sysconf) {
+    if (MPLS_SLOWPATH(!os_sysconf)) {
         os_sysconf = dlsym(RTLD_NEXT, "sysconf");
         /* Something's badly broken if this fails */
         if (!os_sysconf) {

--- a/src/time.c
+++ b/src/time.c
@@ -18,6 +18,8 @@
 /* MP support header */
 #include "MacportsLegacySupport.h"
 
+#include "compiler.h"
+
 #if __MPLS_LIB_SUPPORT_APPROX_TIME__
 
 #include <mach/mach_time.h>
@@ -270,7 +272,7 @@ uint64_t mach_continuous_time(void)
 {
   uint64_t mach_time;
 
-  if (!sleep_offset_valid) get_sleep_offset();
+  if (MPLS_SLOWPATH(!sleep_offset_valid)) get_sleep_offset();
   mach_time = mach_absolute_time();
   return mach_time + sleep_offset;
 }
@@ -279,7 +281,7 @@ uint64_t mach_continuous_approximate_time(void)
 {
   uint64_t mach_time;
 
-  if (!sleep_offset_valid) get_sleep_offset();
+  if (MPLS_SLOWPATH(!sleep_offset_valid)) get_sleep_offset();
   mach_time = mach_approximate_time();
   return mach_time + sleep_offset;
 }
@@ -697,7 +699,7 @@ clock_gettime_nsec_np(clockid_t clk_id)
   uint64_t mach_time;
 
   /* Set up mach scaling early, whether we need it or not. */
-  if (!mach_mult) setup_mach_mult();
+  if (MPLS_SLOWPATH(!mach_mult)) setup_mach_mult();
 
   switch (clk_id) {
 
@@ -751,7 +753,7 @@ clock_gettime(clockid_t clk_id, struct timespec *ts)
   uint64_t mach_time, nanos;
 
   /* Set up mach scaling early, whether we need it or not. */
-  if (!mach_mult) mserr = setup_mach_mult();
+  if (MPLS_SLOWPATH(!mach_mult)) mserr = setup_mach_mult();
 
   switch (clk_id) {
 
@@ -807,7 +809,7 @@ clock_getres(clockid_t clk_id, struct timespec *res)
   int mserr = 0;
 
   /* Set up mach scale factor, whether we need it or not. */
-  if (!res_mach.tv_nsec) mserr = setup_mach_mult();
+  if (MPLS_SLOWPATH(!res_mach.tv_nsec)) mserr = setup_mach_mult();
 
   switch (clk_id) {
 

--- a/test/test_clocks.c
+++ b/test/test_clocks.c
@@ -83,8 +83,8 @@ typedef int64_t sns_time_t;
 #define BILLION64  1000000000ULL
 
 /* Parameters for collection sequence */
-#define MAX_STEP_NS           700000  /* Maximum delta not considered a step */
-#define MAX_APPROX_STEP_NS  10000000  /* Maximum approximate-clock step */
+#define MAX_STEP_NS          1000000  /* Maximum delta not considered a step */
+#define MAX_APPROX_STEP_NS  15000000  /* Maximum approximate-clock step */
 #define MAX_RETRIES               50  /* Maximum soft-error retries */
 #define STD_SLEEP_US            1000  /* Standard sleep before collecting */
 #define MAX_SLEEP_US          100000  /* Maximum sleep when retrying */

--- a/test/test_clonefile.c
+++ b/test/test_clonefile.c
@@ -1,0 +1,158 @@
+/*
+ * Copyright (c) 2025 Frederick H. G. Wright II <fw@fwright.net>
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
+/*
+ * This provides a limited test of *clonefile*(), mainly to test the disallowed
+ * cases on HFS+, since native clonefile() support is available on all OS
+ * versions that support APFS.
+ */
+
+#include <errno.h>
+#include <fcntl.h>
+#include <libgen.h>
+#include <stdio.h>
+#include <string.h>
+#include <unistd.h>
+
+#include <sys/attr.h>
+#include <sys/clonefile.h>
+#include <sys/fcntl.h>
+#include <sys/mount.h>
+#include <sys/param.h>
+
+#ifndef TEST_TEMP
+#define TEST_TEMP "/dev/null"
+#endif
+
+/*
+ * Determine filesystem cloning support for given file.
+ *
+ * -1 error, 0 no cloning allowed, 1 cloning allowed
+ */
+static int
+get_cloneable(const char *path, int verbose)
+{
+  struct statfs sfb;
+  struct attrlist al = {
+      .bitmapcount = ATTR_BIT_MAP_COUNT,
+      .volattr = ATTR_VOL_INFO | ATTR_VOL_CAPABILITIES,
+      };
+  uint32_t abuf[1024] = {0};
+  vol_capabilities_attr_t *vc;
+
+  if (statfs(path, &sfb)) {
+    printf("  statfs() for '%s' failed: %s\n", path, strerror(errno));
+    return -1;
+  }
+  if (verbose) printf("  %s is in volume %s\n", path, sfb.f_mntonname);
+
+  if (getattrlist(sfb.f_mntonname, &al, abuf, sizeof(abuf), 0)) {
+    fprintf(stderr, "  getattrlist() for '%s' failed: %s\n",
+            sfb.f_mntonname, strerror(errno));
+    return -1;
+  }
+  if (abuf[0] != sizeof(*vc) + sizeof(abuf[0])) {
+    printf("  getattrlist() for '%s' returned wrong size: %d\n",
+           sfb.f_mntonname, abuf[0]);
+    return -1;
+  }
+
+  vc = (vol_capabilities_attr_t *) &abuf[1];
+  if (vc->valid[VOL_CAPABILITIES_INTERFACES] & VOL_CAP_INT_CLONE) {
+    if (vc->capabilities[VOL_CAPABILITIES_INTERFACES] & VOL_CAP_INT_CLONE) {
+      if (verbose) printf("    VOL_CAP_INT_CLONE is set\n");
+      return 1;
+    } else {
+      if (verbose) printf("    VOL_CAP_INT_CLONE is not set\n");
+      return 0;
+    }
+  } else {
+    if (verbose) printf("    VOL_CAP_INT_CLONE is unspecified\n");
+    return 0;
+  }
+}
+
+static int
+check_status(int status, const char *call, int verbose)
+{
+  if (status != -1) {
+    printf("  %s unexpectedly succeeded\n", call);
+    return 1;
+  }
+  if (errno != ENOTSUP) {
+    printf("  %s returned incorrect errno: %s (%d)\n",
+           call, strerror(errno), errno);
+    return 1;
+  }
+  if (verbose) {
+    printf("  %s returned expected errno: %s (%d)\n",
+           call, strerror(errno), errno);
+  }
+  return 0;
+}
+
+int
+main(int argc, char *argv[])
+{
+  int verbose = 0, ret = 0, cloneable, fd;
+  char *progname = basename(argv[0]);
+  pid_t pid = getpid();
+  char dest[MAXPATHLEN];
+
+  if (argc > 1 && !strcmp(argv[1], "-v")) verbose = 1;
+
+  (void) snprintf(dest, sizeof(dest), "%s/%s-%u", TEST_TEMP, progname, pid);
+
+  if (verbose) {
+    printf("%s starting.\n", progname);
+    printf("  %s -> %s\n", argv[0], dest);
+  }
+
+  cloneable = get_cloneable(argv[0], verbose);
+  if (cloneable < 0) {
+    printf("%s failed.\n", progname);
+    return 1;
+  }
+  if (cloneable) {
+    printf("%s skipped due to cloneable volume.\n", progname);
+    return 0;
+  }
+
+  ret |= check_status(
+      clonefile(argv[0], dest, 0),
+      "clonefile(<src>, <dst>, 0)",
+      verbose
+      );
+  ret |= check_status(
+      clonefileat(AT_FDCWD, argv[0], AT_FDCWD, dest, 0),
+      "clonefileat(AT_FDCWD, <src>, AT_FDCWD, <dst>, 0)",
+      verbose
+      );
+  if ((fd = open(argv[0], O_RDONLY)) < 0) {
+    printf("  open() for %s failed: %s\n", argv[0], strerror(errno));
+    ret = 1;
+  } else {
+    ret |= check_status(
+        fclonefileat(fd, AT_FDCWD, dest, 0),
+        "fclonefileat(<srcfd>, AT_FDCWD, <dst>, 0)",
+        verbose
+        );
+    (void) close(fd);
+  }
+
+  printf("%s %s.\n", progname, ret ? "failed" : "passed");
+  return ret;
+}

--- a/tools/allheaders.sh
+++ b/tools/allheaders.sh
@@ -31,6 +31,8 @@ FILTERS+='|MacportsLegacySupport.h'
 FILTERS+='|CoreFoundation/|IOKit/|OpenGL/'
 # The 10.5-internal-only available.h
 FILTERS+='|available.h'
+# sys/attr.h requires other headers that it doesn't include
+FILTERS+='|sys/attr.h'
 
 # Headers without .h are C++-only, and not legal in basic-C builds.
 CPPFILTER='[.]h$'

--- a/xtest/allheaders.h
+++ b/xtest/allheaders.h
@@ -24,6 +24,7 @@
 #include <strings.h>
 #include <sys/aio.h>
 #include <sys/cdefs.h>
+#include <sys/clonefile.h>
 #include <sys/fcntl.h>
 #include <sys/fsgetpath.h>
 #include <sys/mman.h>

--- a/xtest/revheaders.h
+++ b/xtest/revheaders.h
@@ -14,6 +14,7 @@
 #include <sys/mman.h>
 #include <sys/fsgetpath.h>
 #include <sys/fcntl.h>
+#include <sys/clonefile.h>
 #include <sys/cdefs.h>
 #include <sys/aio.h>
 #include <strings.h>


### PR DESCRIPTION
Notably:

- Implements sleep-time accounting in clock functions.
- Implements degenerate `*clonefile*()`.

Tested on:
```
Mac OS X 10.4.11 8S165, PPC, Xcode 2.5 8M2558
Mac OS X 10.4.11 8S2167, i386, Xcode 2.5 8M2558
Mac OS X 10.4.11 8S2167, x86_64, Xcode 2.5 8M2558
Mac OS X 10.5.8 9L31a, PPC, Xcode 3.1.4 9M2809
Mac OS X 10.5.8 9L31a, i386, Xcode 3.1.4 9M2809
Mac OS X 10.5.8 9L31a, x86_64, Xcode 3.1.4 9M2809
Mac OS X 10.5.8 9L31a, PPC (i386 Rosetta), Xcode 3.1.4 9M2809
Mac OS X 10.6.8 10K549, i386, Xcode 3.2.6 10M2518
Mac OS X 10.6.8 10K549, x86_64, Xcode 3.2.6 10M2518
Mac OS X 10.6.8 10K549, PPC (i386 Rosetta), Xcode 3.2.6 10M2518
Mac OS X 10.7.5 11G63, x86_64, Xcode 4.6.3 4H1503
OS X 10.8.5 12F2560, x86_64, Xcode 5.1.1 5B1008
OS X 10.9.5 13F1911, x86_64, Xcode 6.2 6C131e
OS X 10.10.5 14F2511, x86_64, Xcode 7.2 7C68
OS X 10.11.6 15G22010, x86_64, Xcode 8.1 8B62
macOS 10.12.6 16G2136, x86_64, Xcode 9.2 9C40b
macOS 10.13.6 17G14042, x86_64, Xcode 10.1 10B61
macOS 10.14.6 18G9323, x86_64, Xcode 11.3.1 11C505
macOS 10.15.7 19H15, x86_64, Xcode 12.4 12D4e
macOS 11.7.10 20G1427, x86_64, Xcode 13.2.1 13C100
macOS 11.7.10 20G1427, arm64, Xcode 13.2.1 13C100
macOS 12.7.6 21H1320, x86_64, Xcode 14.2 14C18
macOS 12.7.6 21H1320, arm64, Xcode 14.2 14C18
macOS 13.7.6 22H625, arm64, Xcode 15.2 15C500b
macOS 14.7.6 23H626, arm64, Xcode 16.2 16C5032a
macOS 15.5 24F74, arm64, Xcode 16.3 16E140
```
