### PR TITLE
Boottime fixes et al

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -537,7 +537,11 @@ test_clean: xtest_clean $(MANRUNPREFIX)clean
 	@$(RMDIR) $(XLIBDIR)
 	$(RM) -r $(TEST_TEMP)
 
-clean: $(MANRUNPREFIX)clean test_clean
+tools_clean:
+	$(RM) $(TOOLDIR)*.o $(TOOLDIR)/boottime $(TOOLDIR)/clock_info
+	$(RM) $(TOOLDIR)/mach_time $(TOOLDIR)/realpath_test
+
+clean: $(MANRUNPREFIX)clean test_clean tools_clean
 	$(RM) $(foreach D,$(SRCDIR),$D/*.o $D/*.o.* $D/*.d)
 	$(RM) $(BUILDDLIBPATH) $(BUILDSLIBPATH) $(BUILDSYSLIBPATH)
 	@$(RMDIR) $(BUILDLIBDIR)

--- a/README.md
+++ b/README.md
@@ -314,6 +314,11 @@ Wrapped headers and replaced functions are:
     <td>Provides a workaround for bug in <code>pthread_get_stacksize_np</code></td>
     <td>OSX10.4, OSX10.5, OSX10.9, OSX10.10</td>
   </tr>
+  <tr>
+    <td><code>-</code></td>
+    <td>Fixes boottime bug in 64-bit <code>sysctl()</code> and <code>sysctlbyname()</code></td>
+    <td>OSX10.5</td>
+  </tr>
 </table>
 
 For information on building this library outside MacPorts, see BUILDING.txt.

--- a/include/MacportsLegacySupport.h
+++ b/include/MacportsLegacySupport.h
@@ -172,6 +172,10 @@
 #define __MPLS_SDK_SUPPORT_TIMESPEC_GET__     (__MPLS_SDK_MAJOR < 101500)
 #define __MPLS_LIB_SUPPORT_TIMESPEC_GET__     (__MPLS_TARGET_OSVER < 101500)
 
+/* Fix bugs in sysctl() and sysctlbyname() for boottime */
+#define __MPLS_LIB_FIX_64BIT_BOOTTIME__       (__MPLS_TARGET_OSVER < 1060 \
+                                               && __MPLS_64BIT)
+
 /* "at" calls, including fdopendir */
 #define __MPLS_SDK_SUPPORT_ATCALLS__          (__MPLS_SDK_MAJOR < 101000)
 #define __MPLS_LIB_SUPPORT_ATCALLS__          (__MPLS_TARGET_OSVER < 101000)

--- a/src/sysctl.c
+++ b/src/sysctl.c
@@ -1,0 +1,140 @@
+/*
+ * Copyright (c) 2025 Frederick H. G. Wright II <fw@fwright.net>
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
+/* MP support header */
+#include "MacportsLegacySupport.h"
+
+#if __MPLS_LIB_FIX_64BIT_BOOTTIME__
+
+#include <dlfcn.h>
+#include <stddef.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include <sys/sysctl.h>
+#include <sys/time.h>
+
+#include "compiler.h"
+
+/*
+ * Under OS <10.6, the returned struct timeval for boottime is always based on
+ * the kernel's 32-bit time_t, even with a 64-bit userspace that expects
+ * the 64-bit time_t version of struct timeval.  This error happens to be
+ * somewhat benign on little-endian machines, but results in complete garbage
+ * on big-endian machines (ppc64).
+ *
+ * To fix this, we detect the misbehavior by observing the incorrect
+ * length, and reformat the data appropriately.
+ */
+
+typedef struct timeval timeval_t;
+
+typedef struct tv32_s {
+  uint32_t tv_sec;  /* Unsigned to get past 2038 */
+  int32_t  tv_usec;
+} tv32_t;
+
+/* See if we got the wrong boottime format, and fix it if so */
+static void
+fix_boottime(timeval_t *oldp, size_t *oldlenp, size_t origlen)
+{
+  tv32_t tv32;
+
+  /* If we wanted a timeval and got a tv32 ... */
+  if (oldp && origlen >= sizeof(*oldp) 
+      && *oldlenp == sizeof(tv32_t) && sizeof(tv32_t) < sizeof(*oldp)) {
+    tv32 = *((tv32_t *) oldp);
+    oldp->tv_sec = tv32.tv_sec;
+    oldp->tv_usec = tv32.tv_usec;
+    *oldlenp = sizeof(*oldp);
+  }
+}
+
+typedef int (sysctl_fn_t)(int *name, u_int namelen, void *oldp, size_t *oldlenp,
+             void *newp, size_t newlen);
+
+int
+sysctl(int *name, u_int namelen, void *oldp, size_t *oldlenp,
+       void *newp, size_t newlen)
+{
+  int ret;
+  size_t origlen;
+  static sysctl_fn_t *os_sysctl = NULL;
+
+  if (MPLS_SLOWPATH(!os_sysctl)) {
+    os_sysctl = dlsym(RTLD_NEXT, "sysctl");
+    /* Something's badly broken if this fails */
+    if (!os_sysctl) {
+        abort();
+    }
+  }
+
+  /* Capture originally specified length */
+  origlen = oldlenp ? *oldlenp : 0;
+
+  /* Do the call; return error on failure */
+  ret = (*os_sysctl)(name, namelen, oldp, oldlenp, newp, newlen);
+  if (ret) return ret;
+
+  /* If we just obtained boottime, possibly correct it */
+  if (namelen >=2 && name[0] == CTL_KERN && name[1] == KERN_BOOTTIME) {
+    fix_boottime(oldp, oldlenp, origlen);
+  }
+
+  return 0;
+}
+
+/*
+ * The same boottime issue also applies to sysctlbyname().  We apply
+ * the same fix to that call.  This does not correct the absence of
+ * this item on 10.4.
+ */
+
+typedef int (sysctlbyname_fn_t)(const char *name, void *oldp, size_t *oldlenp,
+             void *newp, size_t newlen);
+
+int
+sysctlbyname(const char *name, void *oldp, size_t *oldlenp,
+       void *newp, size_t newlen)
+{
+  int ret;
+  size_t origlen;
+  static sysctlbyname_fn_t *os_sysctlbyname = NULL;
+
+  if (MPLS_SLOWPATH(!os_sysctlbyname)) {
+    os_sysctlbyname = dlsym(RTLD_NEXT, "sysctlbyname");
+    /* Something's badly broken if this fails */
+    if (!os_sysctlbyname) {
+        abort();
+    }
+  }
+
+  /* Capture originally specified length */
+  origlen = oldlenp ? *oldlenp : 0;
+
+  /* Do the call; return error on failure */
+  ret = (*os_sysctlbyname)(name, oldp, oldlenp, newp, newlen);
+  if (ret) return ret;
+
+  /* If we just obtained boottime, possibly correct it */
+  if (!strcmp(name, "kern.boottime")) {
+    fix_boottime(oldp, oldlenp, origlen);
+  }
+
+  return 0;
+}
+
+#endif /* __MPLS_LIB_FIX_64BIT_BOOTTIME__ */

--- a/src/time.c
+++ b/src/time.c
@@ -275,13 +275,6 @@ startup_sleep_offset(void)
   get_sleep_offset();
 }
 
-/*
- * For some as-yet-undetermined reason, the sleep offset is causing trouble
- * in ppc64 builds.  So for now, we avoid it on ppc64.
- */
-
-#ifndef __ppc64__
-
 uint64_t mach_continuous_time(void)
 {
   uint64_t mach_time;
@@ -299,20 +292,6 @@ uint64_t mach_continuous_approximate_time(void)
   mach_time = mach_approximate_time();
   return mach_time + sleep_offset;
 }
-
-#else /* __ppc64__ */
-
-uint64_t mach_continuous_time(void)
-{
-  return mach_absolute_time();
-}
-
-uint64_t mach_continuous_approximate_time(void)
-{
-  return mach_approximate_time();
-}
-
-#endif /* __ppc64__ */
 
 #endif /* __MPLS_LIB_SUPPORT_CONTINUOUS_TIME__ */
 

--- a/src/time.c
+++ b/src/time.c
@@ -236,6 +236,11 @@ static void get_sleep_offset(void)
   if (get_sleepofs_info(&si)) return;
 
   toddiff = tvdiff2mach(&si.timeofday, &si.boottime);
+  /* boottime later than tod is garbage */
+  if (toddiff < 0) {
+    sleep_offset_valid = 1;  /* It's permanent garbage, so don't retry this */
+    return;
+  }
   offset = toddiff - (si.mach_before + si.mach_after) / 2;
   minsleepadj = tvdiff2mach(&tv5a, &tv5b);
   maxdrift = (si.mach_before - sleep_info.mach_before)

--- a/test/test_clocks.c
+++ b/test/test_clocks.c
@@ -1201,7 +1201,7 @@ sandwich_samples(clock_idx_t clkidx, errinfo_t *ei)
  * In addition to the above, the "late" case is considered retriable.
  */
 static int
-compare_clocks(clock_idx_t clkidx, errinfo_t *ei, errinfo_t *eir, dstats_t *dp)
+compare_clocks(clock_idx_t clkidx, errinfo_t *ei, errinfo_t *eir)
 {
   const ns_time_t *refbp = &refnsbuf[0];
   const ns_time_t *testbp = nsbufp[clock_types[clkidx]];
@@ -1313,8 +1313,7 @@ static int clock_replay_dual_ns(clock_idx_t clkidx, int quiet);
 
 static int
 check_clock_sandwich(clock_idx_t clkidx,
-                     errinfo_t *ei, errinfo_t *eir, dstats_t *dp,
-                     int quiet, int replay)
+                     errinfo_t *ei, errinfo_t *eir, int quiet, int replay)
 {
   int ret, tries = 0;
   useconds_t sleepus = STD_SLEEP_US;
@@ -1335,7 +1334,7 @@ check_clock_sandwich(clock_idx_t clkidx,
 
     ret = check_samples(clkidx, nsbufp[clock_types[clkidx]], 1, ei);
     if (ret) { if (ret < 0) break; continue; }
-    ret = compare_clocks(clkidx, ei, eir, dp);
+    ret = compare_clocks(clkidx, ei, eir);
     if (ret <= 0) break;
   } while (!replay && ++tries < MAX_RETRIES);
 
@@ -1489,7 +1488,7 @@ report_clock_compare(clock_idx_t clkidx, int dump, int dverbose,
 
   if (vnq) printf("  Comparing %s to mach_absolute_time\n", name);
 
-  if (check_clock_sandwich(clkidx, &info, &refinfo, &dstats, quiet, replay)) {
+  if (check_clock_sandwich(clkidx, &info, &refinfo, quiet, replay)) {
     if (replay && info.retries < 0) return 0;  /* Just skip nonex replay */
     if (refinfo.errnum) {
       report_clock_err(clock_idx_mach_absolute, &refinfo, 0, verbose);
@@ -1542,7 +1541,7 @@ report_all_clock_compares(int dump, int dverbose, int verbose, int quiet, int re
  * "multiply first" approach on PowerPC can be observed.
  *
  * If and when the overflow occurs from using the "multiply first" approach
- * on PowrerPC, the computed nanosecond value wraps around, after which its
+ * on PowerPC, the computed nanosecond value wraps around, after which its
  * value is never more than half the correct value.  Thus, it can be detected
  * on the basis of a very large negative error in the scale (at least 0.5).
  */

--- a/test/test_clocks.c
+++ b/test/test_clocks.c
@@ -2178,8 +2178,7 @@ main(int argc, char *argv[])
 
   err |= check_invalid();
 
-  /* For now, ignore (but report) any boottime error */
-  (void) check_boottime(verbose && !quiet);
+  err |= check_boottime(verbose && !quiet);
 
   get_sleepofs(&lastsleep);
   if (verbose & !quiet) report_sleepofs("  Initial sleep offset", &lastsleep);

--- a/tools/boottime.c
+++ b/tools/boottime.c
@@ -1,0 +1,372 @@
+/*
+ * Copyright (c) 2025 Frederick H. G. Wright II <fw@fwright.net>
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
+/*
+ * This is a tool for obtaining the system boot time, for the purpose
+ * of investigating bugs in that mechanism.
+ *
+ * This tool is intended to be built without legacy-support, but can
+ * optionally load the legacy-support library from either the "system"
+ * location or the relative build-tree location.  In the former case,
+ * the default "/opt/local" prefix is assumed, unless the MPPREFIX
+ * definition is overridden.
+ */
+
+#include <dlfcn.h>
+#include <errno.h>
+#include <libgen.h>
+#include <stddef.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+#include <sys/sysctl.h>
+#include <sys/time.h>
+#include <sys/types.h>
+
+/* RTLD_FIRST is unavailable on 10.4 - make it ignored. */
+#ifndef RTLD_FIRST
+#define RTLD_FIRST 0
+#endif
+
+#if defined(__ppc__)
+#define ARCH "ppc"
+#elif defined(__ppc64__)
+#define ARCH "ppc64"
+#elif defined(__i386__)
+#define ARCH "i386"
+#elif defined(__x86_64__)
+#define ARCH "x86_64"
+#elif defined(__arm__)
+#define ARCH "arm"
+#elif defined(__arm64__) || defined(__aarch64__)
+#define ARCH "arm64"
+#else
+#define ARCH "unknown"
+#endif
+
+#define SYSCTL_OSVER_CLASS CTL_KERN
+#define SYSCTL_OSVER_ITEM  KERN_OSRELEASE
+
+/* sysctl to check whether we're running natively (not Rosetta 1) */
+#define SYSCTL_NATIVE "sysctl.proc_native"
+
+/* sysctl to check whether we're running in Rosetta 2 */
+#define SYSCTL_TRANSLATED "sysctl.proc_translated"
+
+typedef int (sysctl_fn_t)(int *name, u_int namelen,
+             void *oldp, size_t *oldlenp, void *newp, size_t newlen);
+typedef int (sysctlbyname_fn_t)(const char *name,
+             void *oldp, size_t *oldlenp, void *newp, size_t newlen);
+typedef int (sysctlnametomib_fn_t)(const char *name, int *mibp, size_t *sizep);
+
+#ifndef MPPREFIX
+#define MPPREFIX "/opt/local"
+#endif
+#define LIBDIR "lib"
+#define LSLIB "libMacportsLegacySupport.dylib"
+#define MPLSLIB MPPREFIX "/" LIBDIR "/" LSLIB
+#define LOCALLSLIB "../" LIBDIR "/" LSLIB
+
+#define UL (unsigned long)
+
+static char osver[256];
+
+static int
+get_osver(void)
+{
+  int mib[] = {SYSCTL_OSVER_CLASS, SYSCTL_OSVER_ITEM};
+  int miblen = sizeof(mib) / sizeof(mib[0]);
+  size_t len = sizeof(osver);
+
+  if (sysctl(mib, miblen, osver, &len, NULL, 0)) return -1;
+  if (len <= 0 || len >= (ssize_t) sizeof(osver)) return -1;
+  osver[len] = '\0';
+  if (osver[len - 1] == '\n') osver[len - 1] = '\0';
+  return 0;
+}
+
+/* Test whether running under Rosetta */
+/* -1 no, 1 Rosetta 1, 2 Rosetta 2 */
+static int
+check_rosetta(void)
+{
+  int native, translated;
+  size_t native_sz = sizeof(native);
+  size_t translated_sz = sizeof(translated);
+
+  /* Check for Rosetta 1 */
+  if (sysctlbyname(SYSCTL_NATIVE, &native, &native_sz, NULL, 0) < 0) {
+    /* If sysctl failed, must be real ppc. */
+    return -1;
+  }
+  if (!native) return 1;
+
+  /* If "native", check for Rosetta 2 */
+  if (sysctlbyname(SYSCTL_TRANSLATED, &translated, &translated_sz,
+                   NULL, 0) < 0) {
+    /* If sysctl failed, must be really native. */
+    return -1;
+  }
+  return translated ? 2 : -1;
+}
+
+static void *
+load_lib(int legacy, char *progname, int verbose)
+{
+  char *progdir;
+  char lslib[PATH_MAX], lsreal[PATH_MAX];
+  const char *libpath;
+  void *libhandle = NULL;
+
+  if (legacy > 0) {
+    libpath = MPLSLIB;
+  } else {
+    progdir = dirname(progname);
+    (void) snprintf(lslib, sizeof(lslib), "%s/" LOCALLSLIB, progdir);
+    if (!(libpath = realpath(lslib, lsreal))) {
+      printf("Unable to resolve library path '%s': %s\n",
+             lslib, strerror(errno));
+      return NULL;
+    }
+  }
+  if (!(libhandle = dlopen(libpath, RTLD_FIRST))) {
+    printf("Unable to open library: %s\n", dlerror());
+    return NULL;
+  }
+  if (verbose) {
+    printf("    Loaded %s, handle = 0x%0*lX\n", libpath,
+           (int) sizeof(void *) * 2, UL libhandle);
+  }
+  return libhandle;
+}
+
+static void
+close_lib(void **libhandle)
+{
+  if (*libhandle && dlclose(*libhandle)) {
+    printf("Unable to close library: %s\n", dlerror());
+  }
+  *libhandle = NULL;
+}
+
+static void *
+func_lookup(const char *name, void *libhandle, int verbose)
+{
+  void *handle = libhandle;
+  void *adr = NULL;
+
+  /* Try extra library first, then general */
+  if (libhandle) adr = dlsym(handle, name);
+  if (!adr) adr = dlsym((handle = RTLD_NEXT), name);
+
+  if (verbose) {
+    if (!adr) {
+      printf("    %s not found\n", name);
+    } else if (handle == RTLD_NEXT) {
+      printf("    Located %s in library handle RTLD_NEXT\n", name);
+    } else {
+      printf("    Located %s in library handle 0x%0*lX\n", name,
+             (int) sizeof(void *) * 2, UL libhandle);
+    }
+  }
+
+  return adr;
+}
+
+static size_t
+init_bt(struct timeval *bt)
+{
+  uint32_t *ip = (uint32_t *) bt;
+
+  /* Prefill result with garbage, to detect incomplete stores */
+  while (ip < (uint32_t *)(bt + 1)) {
+    *ip++ = 0xDEADBEEFU;
+  }
+  return sizeof(*bt);
+}
+
+static void
+print_err(const char *name, int ret, int err)
+{
+  printf("***  kern.boottime %s returned %d, errno = %d (%s)\n",
+         name, ret, err, strerror(err));
+}
+
+static int
+check_bt(const char *name, int retlen, struct timeval *bt)
+{
+  if (retlen != sizeof(*bt)) {
+    printf("***  kern.boottime %s returned length %d, which should be %d\n",
+           name, retlen, (int) sizeof(*bt));
+    return 1;
+  }
+  if ((unsigned int) bt->tv_usec >= 1000000U) {
+    if (sizeof(bt->tv_usec) > 4) {
+      printf("***  kern.boottime %s tv_usec = 0x%016llX\n",
+             name, (unsigned long long) bt->tv_usec);
+    } else {
+      printf("***  kern.boottime %s tv_usec = 0x%08X\n",
+             name, (unsigned int) bt->tv_usec);
+    }
+    return 1;
+  }
+  return 0;
+}
+
+static void
+print_bt(const char *name, struct timeval *bt)
+{
+  printf("  kern.bootime %s result = { sec = %lld, usec = %lld }\n",
+         name, (long long) bt->tv_sec, (long long) bt->tv_usec);
+}
+
+static void
+show_mib(const char *name, const int *mib, size_t miblen)
+{
+  int val;
+  const int *mibend = mib + miblen;
+
+  printf("  kern.boottime%s mib = [", name);
+  while (mib < mibend) {
+    val = *mib++;
+    printf("%d%s", val, mib < mibend ? ", " : "");
+  }
+  printf("]\n");
+}
+
+static void
+do_flush(void)
+{
+  (void) fflush(stdout);
+}
+
+int
+main(int argc, char *argv[])
+{
+  int ret, err, verbose = 0, legacy = 0, argn = 1;
+  const char *cp;
+  char chr;
+  void *libhandle = NULL;
+  const char *rosetta;
+  struct timeval boottime;
+  size_t boottime_len;
+  int mib[8];
+  size_t miblen;
+
+  sysctlbyname_fn_t *sysctlbyname_p;
+  sysctlnametomib_fn_t *sysctlnametomib_p;
+  sysctl_fn_t *sysctl_p;
+
+  static const int bt_mib[] = {CTL_KERN, KERN_BOOTTIME};
+  static const size_t bt_miblen = sizeof(bt_mib) / sizeof(bt_mib[0]);
+
+  while (argn < argc && argv[argn][0] == '-') {
+    cp = argv[argn];
+    while ((chr = *++cp)) {
+      switch (chr) {
+        case 'v': ++verbose; break;
+        case 'y': legacy = 1; break;
+        case 'Y': legacy = -1; break;
+      }
+    }
+    ++argn;
+  }
+
+  err = get_osver();
+  switch (check_rosetta()) {
+    case -1: rosetta = "native"; break;
+    case 1: rosetta = "Rosetta 1"; break;
+    case 2: rosetta = "Rosetta 2"; break;
+    default: rosetta = "???"; break;
+  }
+  printf("OS is Darwin %s, CPU is %s (%s)\n",
+         err ? "???" : osver, ARCH, rosetta);
+
+  if (legacy) {
+    if (!(libhandle = load_lib(legacy, argv[0], verbose))) return 10;
+  }
+
+  do_flush();  /* In case we crash */
+
+  boottime_len = init_bt(&boottime);
+  if ((sysctlbyname_p = func_lookup("sysctlbyname", libhandle, verbose))) {
+    ret = (*sysctlbyname_p)("kern.boottime", &boottime, &boottime_len, NULL, 0);
+    if (ret) {
+      print_err("by name", ret, errno);
+    } else {
+      ret = check_bt("by name", boottime_len, &boottime);
+    }
+    if (!ret || verbose) {
+      print_bt("by name", &boottime);
+    }
+  }
+  do_flush();  /* In case we crash */
+
+  miblen = sizeof(mib) / sizeof(mib[0]);
+  if ((sysctlnametomib_p = 
+       func_lookup("sysctlnametomib", libhandle, verbose))) {
+    ret = (*sysctlnametomib_p)("kern.boottime", mib, &miblen);
+    if (ret) {
+      print_err("to mib", ret, errno);
+      miblen = 0;
+    }
+    if (!ret || verbose) {
+      show_mib("", mib, miblen);
+    }
+  } else miblen = 0;
+  do_flush();  /* In case we crash */
+
+  sysctl_p = func_lookup("sysctl", libhandle, verbose);
+
+  if (miblen) {
+    boottime_len = init_bt(&boottime);
+    if (sysctl_p) {
+      ret = (*sysctl_p)(mib, miblen, &boottime, &boottime_len, NULL, 0);
+      if (ret) {
+        print_err("by mib", ret, errno);
+      } else {
+        ret = check_bt("by mib", boottime_len, &boottime);
+      }
+      if (!ret || verbose) {
+        print_bt("by mib", &boottime);
+      }
+    }
+  }
+  do_flush();  /* In case we crash */
+
+  boottime_len = init_bt(&boottime);
+  memcpy(mib, bt_mib, bt_miblen * sizeof(bt_mib[0]));
+  show_mib(" by consts", mib, bt_miblen);
+  do_flush();  /* In case we crash */
+  if (sysctl_p) {
+    ret = (*sysctl_p)(mib, bt_miblen, &boottime, &boottime_len, NULL, 0);
+    if (ret) {
+      print_err("by consts", ret, errno);
+    } else {
+      ret = check_bt("by consts", boottime_len, &boottime);
+    }
+    if (!ret || verbose) {
+      print_bt("by consts", &boottime);
+    }
+  }
+  do_flush();  /* In case we crash */
+
+  close_lib(&libhandle);
+
+  return 0;
+}


### PR DESCRIPTION
Notably:

- Fixes boottime sysctls for 64-bit <10.6
- Consequently undisables sleep offset on ppc64

Tested on:
```
Mac OS X 10.4.11 8S165, ppc, Xcode 2.5 8M2558
Mac OS X 10.4.11 8S165, ppc64, Xcode 2.5 8M2558
Mac OS X 10.4.11 8S2167, i386, Xcode 2.5 8M2558
Mac OS X 10.4.11 8S2167, x86_64, Xcode 2.5 8M2558
Mac OS X 10.4.11 8S2167, ppc (i386 Rosetta), Xcode 2.5 8M2558
Mac OS X 10.5.8 9L31a, ppc, Xcode 3.1.4 9M2809
Mac OS X 10.5.8 9L31a, ppc64, Xcode 3.1.4 9M2809
Mac OS X 10.5.8 9L31a, i386, Xcode 3.1.4 9M2809
Mac OS X 10.5.8 9L31a, x86_64, Xcode 3.1.4 9M2809
Mac OS X 10.5.8 9L31a, ppc (i386 Rosetta), Xcode 3.1.4 9M2809
Mac OS X 10.6.8 10K549, i386, Xcode 3.2.6 10M2518
Mac OS X 10.6.8 10K549, x86_64, Xcode 3.2.6 10M2518
Mac OS X 10.6.8 10K549, ppc (i386 Rosetta), Xcode 3.2.6 10M2518
Mac OS X 10.7.5 11G63, x86_64, Xcode 4.6.3 4H1503
OS X 10.8.5 12F2560, x86_64, Xcode 5.1.1 5B1008
OS X 10.9.5 13F1911, x86_64, Xcode 6.2 6C131e
OS X 10.10.5 14F2511, x86_64, Xcode 7.2 7C68
OS X 10.11.6 15G22010, x86_64, Xcode 8.1 8B62
macOS 10.12.6 16G2136, x86_64, Xcode 9.2 9C40b
macOS 10.13.6 17G14042, x86_64, Xcode 10.1 10B61
macOS 10.14.6 18G9323, x86_64, Xcode 11.3.1 11C505
macOS 10.15.7 19H15, x86_64, Xcode 12.4 12D4e
macOS 11.7.10 20G1427, x86_64, Xcode 13.2.1 13C100
macOS 11.7.10 20G1427, arm64, Xcode 13.2.1 13C100
macOS 12.7.6 21H1320, x86_64, Xcode 14.2 14C18
macOS 12.7.6 21H1320, arm64, Xcode 14.2 14C18
macOS 13.7.6 22H625, arm64, Xcode 15.2 15C500b
macOS 14.7.6 23H626, arm64, Xcode 16.2 16C5032a
macOS 15.5 24F74, arm64, Xcode 16.3 16E140
```
