### PR TITLE
fix overflow in get_thread_usage_(ns/ts) functions

### DIFF
--- a/src/time.c
+++ b/src/time.c
@@ -695,7 +695,7 @@ get_thread_usage_ns(void)
 {
   static uint64_t (*syscall64)(int, ...) = NULL;
   if (!syscall64)
-    syscall64 = dlfcn(RTLD_NEXT, "syscall");
+    syscall64 = dlsym(RTLD_NEXT, "syscall");
 
   uint64_t mach_time = syscall64(SYS_thread_selfusage);
 
@@ -708,7 +708,7 @@ get_thread_usage_ts(struct timespec *ts)
 {
   static uint64_t (*syscall64)(int, ...) = NULL;
   if (!syscall64)
-    syscall64 = dlfcn(RTLD_NEXT, "syscall");
+    syscall64 = dlsym(RTLD_NEXT, "syscall");
 
   uint64_t mach_time = syscall64(SYS_thread_selfusage);
 

--- a/src/time.c
+++ b/src/time.c
@@ -690,13 +690,12 @@ get_thread_usage_ts(struct timespec *ts)
  *
  * We do a trick here to override the return type of syscall to avoid overflows.
  */
+
+extern uint64_t syscall64(int, ...) __asm("_syscall");
+
 static inline uint64_t
 get_thread_usage_ns(void)
 {
-  static uint64_t (*syscall64)(int, ...) = NULL;
-  if (!syscall64)
-    syscall64 = dlsym(RTLD_NEXT, "syscall");
-
   uint64_t mach_time = syscall64(SYS_thread_selfusage);
 
   return mach2nanos(mach_time);
@@ -706,10 +705,6 @@ get_thread_usage_ns(void)
 static inline int
 get_thread_usage_ts(struct timespec *ts)
 {
-  static uint64_t (*syscall64)(int, ...) = NULL;
-  if (!syscall64)
-    syscall64 = dlsym(RTLD_NEXT, "syscall");
-
   uint64_t mach_time = syscall64(SYS_thread_selfusage);
 
   mach2timespec(mach_time, ts);


### PR DESCRIPTION
You are using the SYS_thread_selfusage syscall, which returns a uin64_t, but the syscall function has a return type of int, this causes the return value to overflow at 2^31, and since this will only run on 10.10 or 10.11, where x86 is the only supported platform, and mach time scales directly to nanoseconds, that means this breaks for threads that run longer than slightly more than 2 seconds.  We can get around that by declaring our own function pointer with a uint64_t return type and using dlfcn to get a function pointer, allowing us to override the return type and access the full 64 bits.