### PR TITLE
Fix (and test update) for thread-time bug, plus a few other minor fixes

### DIFF
--- a/tools/archrun.sh
+++ b/tools/archrun.sh
@@ -20,7 +20,7 @@ ARGS="$@"
 
 DEST="$PROG-$ARCH"
 
-LIPO=lipo
+LIPO="/usr/bin/lipo"
 
 if [ "$ARCH" != 'ppc' ]; then
   $LIPO "$PROG" -thin "$ARCH" -output "$DEST" && exec "$DEST" "$ARGS"

--- a/tools/runnablearchs.sh
+++ b/tools/runnablearchs.sh
@@ -2,24 +2,30 @@
 
 # Script to determine which architectures can build and run on this machine.
 # The list of architectures to test can be specified on the command line;
-# the default is to test all known architectures.  The final output is
+# the default is to test all primary architectures.  The final output is
 # the filtered architecture list.
 #
 # We need to verify that the program can actually run; not just that it built.
 #
 # Some gccs ignore unsupported -arch options, so we need to include a check
-# in the test program to verify the expected architecture.
+# in the test program to verify the expected architecture.  But since there's
+# no '__ppc7400__' preprocessor flag, we need to map 'ppc7400' to 'ppc' while
+# doing this.
 #
 # In addition, some MacPorts clangs segfault when given unsupported -arch
-# options, causing an error message from bash rather than clang.  To get
+# options, causing an error message from the shell rather than clang.  To get
 # around this, we wrap the entire compiler execution in another level of
 # shell, so that we can suppress the error message.
 #
 # Similarly, attempting to run an executable with an unsupported architecture
 # sometimes produces an error message from the shell, so we also wrap this
 # in another shell to allow suppressing the error message.
+#
+# Furthermore, attempts to run an arm64e executable (on arm64) fail with the
+# very nasty signal 9, so we also need to redirect the test program's own
+# stderr to hide that.
 
-ALLARCHS="${@:-ppc ppc64 i386 x86_64 arm64}"
+TESTARCHS="${@:-ppc ppc64 i386 x86_64 arm64}"
 
 if [ "$CC" == "" ]; then CC=cc; fi
 
@@ -27,13 +33,18 @@ TESTBIN="/tmp/testprog-$$"
 TESTSRC="${TESTBIN}.c"
 
 RUNARCHS=""
-for a in $ALLARCHS; do
+for a in $TESTARCHS; do
+  if [ "$a" == "ppc7400" ]; then
+    archflag="ppc"
+  else
+    archflag="$a"
+  fi
 	cat >$TESTSRC <<EOD
 	int
 	main(int argc, char *argv[])
 	{
 		(void) argc; (void) argv;
-	  #ifdef __${a}__
+	  #ifdef __${archflag}__
   		return 0;
   	#else
   	  return 1;
@@ -42,7 +53,7 @@ for a in $ALLARCHS; do
 EOD
   rm -f $TESTBIN
   if sh -c "$CC -arch $a $TESTSRC -o $TESTBIN 2>/dev/null" 2>/dev/null; then
-    if sh -c "$TESTBIN" 2>/dev/null; then
+    if sh -c "$TESTBIN 2>/dev/null" 2>/dev/null; then
       RUNARCHS="$RUNARCHS $a"
     fi
   fi;


### PR DESCRIPTION
Notably:

- Fixes thread time bug on 10.10-10.11.

Tested on:
```
Mac OS X 10.4.11 8S165, ppc, Xcode 2.5 8M2558
Mac OS X 10.4.11 8S165, ppc64, Xcode 2.5 8M2558
Mac OS X 10.4.11 8S2167, i386, Xcode 2.5 8M2558
Mac OS X 10.4.11 8S2167, x86_64, Xcode 2.5 8M2558
Mac OS X 10.4.11 8S2167, ppc (i386 Rosetta), Xcode 2.5 8M2558
Mac OS X 10.5.8 9L31a, ppc, Xcode 3.1.4 9M2809
Mac OS X 10.5.8 9L31a, ppc64, Xcode 3.1.4 9M2809
Mac OS X 10.5.8 9L31a, i386, Xcode 3.1.4 9M2809
Mac OS X 10.5.8 9L31a, x86_64, Xcode 3.1.4 9M2809
Mac OS X 10.5.8 9L31a, ppc (i386 Rosetta), Xcode 3.1.4 9M2809
Mac OS X 10.6.8 10K549, i386, Xcode 3.2.6 10M2518
Mac OS X 10.6.8 10K549, x86_64, Xcode 3.2.6 10M2518
Mac OS X 10.6.8 10K549, ppc (i386 Rosetta), Xcode 3.2.6 10M2518
Mac OS X 10.7.5 11G63, x86_64, Xcode 4.6.3 4H1503
OS X 10.8.5 12F2560, x86_64, Xcode 5.1.1 5B1008
OS X 10.9.5 13F1911, x86_64, Xcode 6.2 6C131e
OS X 10.10.5 14F2511, x86_64, Xcode 7.2 7C68
OS X 10.11.6 15G22010, x86_64, Xcode 8.1 8B62
macOS 10.12.6 16G2136, x86_64, Xcode 9.2 9C40b
macOS 10.13.6 17G14042, x86_64, Xcode 10.1 10B61
macOS 10.14.6 18G9323, x86_64, Xcode 11.3.1 11C505
macOS 10.15.7 19H15, x86_64, Xcode 12.4 12D4e
macOS 11.7.10 20G1427, x86_64, Xcode 13.2.1 13C100
macOS 11.7.10 20G1427, arm64, Xcode 13.2.1 13C100
macOS 12.7.6 21H1320, x86_64, Xcode 14.2 14C18
macOS 12.7.6 21H1320, arm64, Xcode 14.2 14C18
macOS 13.7.6 22H625, arm64, Xcode 15.2 15C500b
macOS 14.7.6 23H626, arm64, Xcode 16.2 16C5032a
macOS 15.5 24F74, arm64, Xcode 16.4 16F6
```
